### PR TITLE
Add empty line between header and table for Section 4.0 Command Summary

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -116,8 +116,9 @@ Q: How do I transfer my data to another Computer?
 A: Install the app on the other computer and overwrite the empty data file it creates with the file that contains the data of your previous MedBook folder.  
 
 ## 4.0 Command Summary
+
 | Action | Format Example |
-| ------ | -------------- |
+| :----- | :------------- |
 | Add Contact Info | /create -t contact -i NRIC -n NAME -p PHONE_NUMBER -e EMAIL -a ADDRESS |
 | View Contact Info | /view -t contact [-i NRIC] [-n NAME] [-p PHONE_NUMBER] [-e EMAIL] |
 | Delete Contact Info | /delete -t contact -i NRIC |


### PR DESCRIPTION
Add an empty line between header and table to fix how the table is rendered on GitHub Pages. Refer to: https://github.com/pages-themes/cayman/issues/82