### PR TITLE
feat: Delete Test Result Command #30

### DIFF
--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -13,5 +13,7 @@ public class Messages {
     public static final String MESSAGE_MEDICALS_LISTED_OVERVIEW = "%1$d medical information listed! Belongs to: %2$s";
     public static final String MESSAGE_PRESCRIPTIONS_LISTED_OVERVIEW = "%1$d prescription listed! Belongs to: %2$s";
     public static final String MESSAGE_TEST_RESULTS_LISTED_OVERVIEW = "%1$d test results listed! Belongs to: %2$s";
+    public static final String MESSAGE_INVALID_TEST_RESULT_DISPLAYED_INDEX =
+            "The test result index provided is invalid";
 
 }

--- a/src/main/java/seedu/address/logic/commands/CommandType.java
+++ b/src/main/java/seedu/address/logic/commands/CommandType.java
@@ -10,6 +10,7 @@ import seedu.address.logic.parser.medical.ViewMedicalCommandParser;
 import seedu.address.logic.parser.prescription.AddPrescriptionCommandParser;
 import seedu.address.logic.parser.prescription.ViewPrescriptionCommandParser;
 import seedu.address.logic.parser.testresult.AddTestResultCommandParser;
+import seedu.address.logic.parser.testresult.DeleteTestResultCommandParser;
 import seedu.address.logic.parser.testresult.ViewTestResultCommandParser;
 
 public enum CommandType {
@@ -77,7 +78,7 @@ public enum CommandType {
     }
 
     /**
-     * Returns command related to adding information to patients in Medbook.
+     * Returns command related to viewing information to patients in Medbook.
      *
      * @param commandType user input command type
      * @param arguments user input arguments
@@ -98,6 +99,33 @@ public enum CommandType {
             return new ViewPrescriptionCommandParser().parse(arguments);
         case TEST:
             return new ViewTestResultCommandParser().parse(arguments);
+        default:
+            throw new ParseException(MESSAGE_CONSTRAINTS);
+        }
+    }
+
+    /**
+     * Returns command related to deleting information to patients in Medbook.
+     *
+     * @param commandType user input command type
+     * @param arguments user input arguments
+     * @return the command based on the user input
+     */
+    public static Command parseDeleteCommandType(String commandType, String arguments) throws ParseException {
+        requireNonNull(commandType);
+        CommandType parsedCommandType = parseCommandType(commandType);
+
+        switch(parsedCommandType) {
+        case CONTACT:
+            throw new ParseException("WIP: Contact type");
+        case MEDICAL:
+            throw new ParseException("WIP: Medical type");
+        case CONSULTATION:
+            throw new ParseException("WIP: Consultation type");
+        case PRESCRIPTION:
+            throw new ParseException("WIP: Prescription type");
+        case TEST:
+            return new DeleteTestResultCommandParser().parse(arguments);
         default:
             throw new ParseException(MESSAGE_CONSTRAINTS);
         }

--- a/src/main/java/seedu/address/logic/commands/testresult/AddTestResultCommand.java
+++ b/src/main/java/seedu/address/logic/commands/testresult/AddTestResultCommand.java
@@ -25,7 +25,7 @@ public class AddTestResultCommand extends Command {
             + PREFIX_TYPE + "test"
             + ": Adds the results of a test taken for a patient in the MedBook. "
             + "Parameters: "
-            + PREFIX_NRIC + "OWNER_NRIC "
+            + PREFIX_NRIC + "PATIENT_NRIC "
             + PREFIX_TESTDATE + "TEST_DATE "
             + PREFIX_MEDICALTEST + "MEDICAL_TEST "
             + PREFIX_RESULT + "TEST_RESULT "
@@ -42,25 +42,25 @@ public class AddTestResultCommand extends Command {
     public static final String MESSAGE_MISSING_PATIENT = "This patient does not exists in MedBook";
 
     // Identifier
-    private final Nric ownerNric;
+    private final Nric patientNric;
 
     private final TestResult toAdd;
 
     /**
      * Creates an AddTestResultCommand to add the specified {@code TestResult}
      */
-    public AddTestResultCommand(Nric ownerNric, TestResult testResult) {
-        requireNonNull(ownerNric);
+    public AddTestResultCommand(Nric patientNric, TestResult testResult) {
+        requireNonNull(patientNric);
         requireNonNull(testResult);
         toAdd = testResult;
-        this.ownerNric = ownerNric;
+        this.patientNric = patientNric;
     }
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
 
-        if (!model.hasPerson(new NricPredicate(ownerNric))) {
+        if (!model.hasPerson(new NricPredicate(patientNric))) {
             throw new CommandException(MESSAGE_MISSING_PATIENT);
         }
 
@@ -69,7 +69,7 @@ public class AddTestResultCommand extends Command {
         }
 
         model.addTestResult(toAdd);
-        model.updateFilteredTestResultList(new TestResultWithNricPredicate(ownerNric));
+        model.updateFilteredTestResultList(new TestResultWithNricPredicate(patientNric));
 
         return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd), COMMAND_TYPE);
     }

--- a/src/main/java/seedu/address/logic/commands/testresult/AddTestResultCommand.java
+++ b/src/main/java/seedu/address/logic/commands/testresult/AddTestResultCommand.java
@@ -31,7 +31,7 @@ public class AddTestResultCommand extends Command {
             + PREFIX_RESULT + "TEST_RESULT "
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_TYPE + "test "
-            + PREFIX_NRIC + "S1234568L "
+            + PREFIX_NRIC + "S1234567L "
             + PREFIX_TESTDATE + "2022-03-16 "
             + PREFIX_MEDICALTEST + "CT Scan "
             + PREFIX_RESULT + "Brain damage ";

--- a/src/main/java/seedu/address/logic/commands/testresult/DeleteTestResultCommand.java
+++ b/src/main/java/seedu/address/logic/commands/testresult/DeleteTestResultCommand.java
@@ -1,6 +1,8 @@
 package seedu.address.logic.commands.testresult;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_INDEX;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NRIC;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TYPE;
 
 import java.util.List;
@@ -23,10 +25,14 @@ public class DeleteTestResultCommand extends Command {
     public static final CommandType COMMAND_TYPE = CommandType.TEST;
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + " "
-            + PREFIX_TYPE + "test " + "ID"
+            + PREFIX_TYPE + "test "
+            + PREFIX_NRIC + "PATIENT_NRIC "
+            + PREFIX_INDEX + "INDEX"
             + ": Deletes the test result identified by the index number used in the displayed test result list.\n"
             + "Parameters: INDEX (must be a positive integer)\n"
-            + "Example: " + COMMAND_WORD + " " + PREFIX_TYPE + "test " + "1";
+            + "Example: " + COMMAND_WORD + " " + PREFIX_TYPE + "test "
+            + PREFIX_NRIC + "S1234567L "
+            + PREFIX_INDEX + "1";
 
     public static final String MESSAGE_DELETE_TEST_RESULT_SUCCESS = "Deleted Test Result: %1$s";
 

--- a/src/main/java/seedu/address/logic/commands/testresult/DeleteTestResultCommand.java
+++ b/src/main/java/seedu/address/logic/commands/testresult/DeleteTestResultCommand.java
@@ -1,0 +1,59 @@
+package seedu.address.logic.commands.testresult;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TYPE;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.Command;
+import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.CommandType;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.testresult.TestResult;
+
+import java.util.List;
+
+/**
+ * Deletes a person identified using it's displayed index from the address book.
+ */
+public class DeleteTestResultCommand extends Command {
+
+    public static final String COMMAND_WORD = "delete";
+    public static final CommandType COMMAND_TYPE = CommandType.TEST;
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + " "
+            + PREFIX_TYPE + "test " + "ID"
+            + ": Deletes the test result identified by the index number used in the displayed test result list.\n"
+            + "Parameters: INDEX (must be a positive integer)\n"
+            + "Example: " + COMMAND_WORD + " " + PREFIX_TYPE + "test " + "1";
+
+    public static final String MESSAGE_DELETE_TEST_RESULT_SUCCESS = "Deleted Test Result: %1$s";
+
+    private final Index targetIndex;
+
+    public DeleteTestResultCommand(Index targetIndex) {
+        this.targetIndex = targetIndex;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<TestResult> lastShownList = model.getFilteredTestResultList();
+
+        if (targetIndex.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_TEST_RESULT_DISPLAYED_INDEX);
+        }
+
+        TestResult testResultToDelete = lastShownList.get(targetIndex.getZeroBased());
+        model.deleteTestResult(testResultToDelete);
+        return new CommandResult(String.format(MESSAGE_DELETE_TEST_RESULT_SUCCESS, testResultToDelete), COMMAND_TYPE);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof DeleteTestResultCommand // instanceof handles nulls
+                && targetIndex.equals(((DeleteTestResultCommand) other).targetIndex)); // state check
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/testresult/DeleteTestResultCommand.java
+++ b/src/main/java/seedu/address/logic/commands/testresult/DeleteTestResultCommand.java
@@ -3,16 +3,16 @@ package seedu.address.logic.commands.testresult;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TYPE;
 
-import seedu.address.commons.core.Messages;
+import java.util.List;
+
 import seedu.address.commons.core.index.Index;
+import seedu.address.commons.core.Messages;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.CommandType;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.testresult.TestResult;
-
-import java.util.List;
 
 /**
  * Deletes a person identified using it's displayed index from the address book.

--- a/src/main/java/seedu/address/logic/commands/testresult/DeleteTestResultCommand.java
+++ b/src/main/java/seedu/address/logic/commands/testresult/DeleteTestResultCommand.java
@@ -5,8 +5,8 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_TYPE;
 
 import java.util.List;
 
-import seedu.address.commons.core.index.Index;
 import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.CommandType;

--- a/src/main/java/seedu/address/logic/commands/testresult/ViewTestResultCommand.java
+++ b/src/main/java/seedu/address/logic/commands/testresult/ViewTestResultCommand.java
@@ -28,29 +28,29 @@ public class ViewTestResultCommand extends Command {
             + "Parameters: PATIENT NRIC\n"
             + "Example: " + COMMAND_WORD + " " + PREFIX_TYPE + "test " + PREFIX_NRIC + "S1234567L";
 
-    private final Nric ownerNric;
+    private final Nric patientNric;
 
     /**
-     * Creates an ViewTestResultCommand to view the specified {@code ownerNric}
+     * Creates an ViewTestResultCommand to view the specified {@code patientNric}
      */
-    public ViewTestResultCommand(Nric ownerNric) {
-        requireNonNull(ownerNric);
-        this.ownerNric = ownerNric;
+    public ViewTestResultCommand(Nric patientNric) {
+        requireNonNull(patientNric);
+        this.patientNric = patientNric;
     }
 
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-        model.updateFilteredTestResultList(new TestResultWithNricPredicate(ownerNric));
+        model.updateFilteredTestResultList(new TestResultWithNricPredicate(patientNric));
 
-        if (!model.hasPerson(new NricPredicate(ownerNric))) {
+        if (!model.hasPerson(new NricPredicate(patientNric))) {
             throw new CommandException(MESSAGE_MISSING_PATIENT);
         }
 
         return new CommandResult(
                 String.format(Messages.MESSAGE_TEST_RESULTS_LISTED_OVERVIEW,
-                        model.getFilteredTestResultList().size(), ownerNric),
+                        model.getFilteredTestResultList().size(), patientNric),
                 COMMAND_TYPE);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/testresult/ViewTestResultCommand.java
+++ b/src/main/java/seedu/address/logic/commands/testresult/ViewTestResultCommand.java
@@ -22,9 +22,10 @@ public class ViewTestResultCommand extends Command {
     public static final String COMMAND_WORD = "view";
     public static final CommandType COMMAND_TYPE = CommandType.TEST;
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Lists all test results whose tests contain any of "
-            + "the specified owner NRIC and displays them as a list with index numbers.\n"
-            + "Parameters: OWNER NRIC\n"
+    public static final String MESSAGE_USAGE = COMMAND_WORD + " " + PREFIX_TYPE + "test " + PREFIX_NRIC + "PATIENT_NRIC"
+            + ": Lists all test results whose tests contain any of "
+            + "the specified patient NRIC and displays them as a list with index numbers.\n"
+            + "Parameters: PATIENT NRIC\n"
             + "Example: " + COMMAND_WORD + " " + PREFIX_TYPE + "test " + PREFIX_NRIC + "S1234567L";
 
     private final Nric ownerNric;

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -3,8 +3,8 @@ package seedu.address.logic.parser;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.address.logic.commands.CommandType.parseAddCommandType;
-import static seedu.address.logic.commands.CommandType.parseViewCommandType;
 import static seedu.address.logic.commands.CommandType.parseDeleteCommandType;
+import static seedu.address.logic.commands.CommandType.parseViewCommandType;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TYPE;
 
 import java.util.regex.Matcher;

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -4,6 +4,7 @@ import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.address.logic.commands.CommandType.parseAddCommandType;
 import static seedu.address.logic.commands.CommandType.parseViewCommandType;
+import static seedu.address.logic.commands.CommandType.parseDeleteCommandType;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TYPE;
 
 import java.util.regex.Matcher;
@@ -59,6 +60,9 @@ public class AddressBookParser {
             return new EditCommandParser().parse(arguments);
 
         case DeleteCommand.COMMAND_WORD:
+            if (argMultimap.getValue(PREFIX_TYPE).isPresent()) {
+                return parseDeleteCommandType(argMultimap.getValue(PREFIX_TYPE).get(), arguments);
+            }
             return new DeleteCommandParser().parse(arguments);
 
         case ClearCommand.COMMAND_WORD:

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -29,4 +29,5 @@ public class CliSyntax {
     public static final Prefix PREFIX_IMMUNIZATION_HISTORY = new Prefix("ih/");
     public static final Prefix PREFIX_GENDER = new Prefix("gd/");
     public static final Prefix PREFIX_ETHNICITY = new Prefix("et/");
+    public static final Prefix PREFIX_INDEX = new Prefix("id/");
 }

--- a/src/main/java/seedu/address/logic/parser/testresult/DeleteTestResultCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/testresult/DeleteTestResultCommandParser.java
@@ -1,0 +1,52 @@
+package seedu.address.logic.parser.testresult;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_INDEX;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TYPE;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.testresult.DeleteTestResultCommand;
+import seedu.address.logic.parser.ArgumentMultimap;
+import seedu.address.logic.parser.ArgumentTokenizer;
+import seedu.address.logic.parser.Parser;
+import seedu.address.logic.parser.ParserUtil;
+import seedu.address.logic.parser.Prefix;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+import java.util.stream.Stream;
+
+/**
+ * Parses input arguments and creates a new DeleteCommand object
+ */
+public class DeleteTestResultCommandParser implements Parser<DeleteTestResultCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the DeleteTestResultCommand
+     * and returns a DeleteTestResultCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public DeleteTestResultCommand parse(String args) throws ParseException {
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_TYPE, PREFIX_INDEX);
+        if (!arePrefixesPresent(argMultimap, PREFIX_TYPE, PREFIX_INDEX)
+                || !argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteTestResultCommand.MESSAGE_USAGE));
+        }
+        try {
+            Index index = ParserUtil.parseIndex(argMultimap.getValue(PREFIX_INDEX).get());
+            return new DeleteTestResultCommand(index);
+        } catch (ParseException pe) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteTestResultCommand.MESSAGE_USAGE), pe);
+        }
+    }
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
+
+}

--- a/src/main/java/seedu/address/logic/parser/testresult/DeleteTestResultCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/testresult/DeleteTestResultCommandParser.java
@@ -4,6 +4,8 @@ import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT
 import static seedu.address.logic.parser.CliSyntax.PREFIX_INDEX;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TYPE;
 
+import java.util.stream.Stream;
+
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.testresult.DeleteTestResultCommand;
 import seedu.address.logic.parser.ArgumentMultimap;
@@ -12,8 +14,6 @@ import seedu.address.logic.parser.Parser;
 import seedu.address.logic.parser.ParserUtil;
 import seedu.address.logic.parser.Prefix;
 import seedu.address.logic.parser.exceptions.ParseException;
-
-import java.util.stream.Stream;
 
 /**
  * Parses input arguments and creates a new DeleteCommand object
@@ -30,7 +30,8 @@ public class DeleteTestResultCommandParser implements Parser<DeleteTestResultCom
                 ArgumentTokenizer.tokenize(args, PREFIX_TYPE, PREFIX_INDEX);
         if (!arePrefixesPresent(argMultimap, PREFIX_TYPE, PREFIX_INDEX)
                 || !argMultimap.getPreamble().isEmpty()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteTestResultCommand.MESSAGE_USAGE));
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    DeleteTestResultCommand.MESSAGE_USAGE));
         }
         try {
             Index index = ParserUtil.parseIndex(argMultimap.getValue(PREFIX_INDEX).get());

--- a/src/main/java/seedu/address/model/testresult/TestResult.java
+++ b/src/main/java/seedu/address/model/testresult/TestResult.java
@@ -12,8 +12,8 @@ import seedu.address.model.patient.Nric;
  */
 public class TestResult {
 
-    // Relationship fields - owner nric
-    private final Nric ownerNric;
+    // Relationship fields - patient nric
+    private final Nric patientNric;
 
     // Data fields
     private final TestDate testDate;
@@ -23,16 +23,16 @@ public class TestResult {
     /**
      * Every field must be present and not null.
      */
-    public TestResult(Nric ownerNric, TestDate testDate, MedicalTest medicalTest, Result result) {
-        requireAllNonNull(ownerNric, testDate, medicalTest, result);
-        this.ownerNric = ownerNric;
+    public TestResult(Nric patientNric, TestDate testDate, MedicalTest medicalTest, Result result) {
+        requireAllNonNull(patientNric, testDate, medicalTest, result);
+        this.patientNric = patientNric;
         this.testDate = testDate;
         this.medicalTest = medicalTest;
         this.result = result;
     }
 
-    public Nric getOwnerNric() {
-        return ownerNric;
+    public Nric getPatientNric() {
+        return patientNric;
     }
 
     public TestDate getTestDate() {
@@ -49,7 +49,7 @@ public class TestResult {
 
 
     /**
-     * Returns true if both test results have the same owner, date, medical test taken and test result.
+     * Returns true if both test results have the same patient, date, medical test taken and test result.
      * This defines a weaker notion of equality between two test results.
      */
     public boolean isSameTestResult(TestResult otherTestResult) {
@@ -58,7 +58,7 @@ public class TestResult {
         }
 
         return otherTestResult != null
-                && otherTestResult.getOwnerNric().equals(getOwnerNric())
+                && otherTestResult.getPatientNric().equals(getPatientNric())
                 && otherTestResult.getTestDate().equals(getTestDate())
                 && otherTestResult.getMedicalTest().equals(getMedicalTest())
                 && otherTestResult.getResult().equals(getResult());
@@ -79,7 +79,7 @@ public class TestResult {
         }
 
         TestResult otherTestResult = (TestResult) other;
-        return otherTestResult.getOwnerNric().equals(getOwnerNric())
+        return otherTestResult.getPatientNric().equals(getPatientNric())
                 && otherTestResult.getTestDate().equals(getTestDate())
                 && otherTestResult.getMedicalTest().equals(getMedicalTest())
                 && otherTestResult.getResult().equals(getResult());
@@ -94,8 +94,8 @@ public class TestResult {
     @Override
     public String toString() {
         final StringBuilder builder = new StringBuilder();
-        builder.append("Owner NRIC: ")
-                .append(getOwnerNric())
+        builder.append("Patient NRIC: ")
+                .append(getPatientNric())
                 .append("; Test Date: ")
                 .append(getTestDate())
                 .append("; Test Taken: ")

--- a/src/main/java/seedu/address/model/testresult/TestResultWithNricPredicate.java
+++ b/src/main/java/seedu/address/model/testresult/TestResultWithNricPredicate.java
@@ -13,7 +13,7 @@ public class TestResultWithNricPredicate implements Predicate<TestResult> {
 
     @Override
     public boolean test(TestResult testResult) {
-        return testResult.getOwnerNric().equals(nric);
+        return testResult.getPatientNric().equals(nric);
     }
 
     @Override

--- a/src/main/java/seedu/address/storage/JsonAdaptedTestResult.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedTestResult.java
@@ -17,7 +17,7 @@ import seedu.address.model.testresult.TestResult;
 class JsonAdaptedTestResult {
     public static final String MISSING_FIELD_MESSAGE_FORMAT = "Test result's %s field is missing!";
 
-    private final String ownerNric;
+    private final String patientNric;
     private final String testDate;
     private final String medicalTest;
     private final String result;
@@ -26,11 +26,11 @@ class JsonAdaptedTestResult {
      * Constructs a {@code JsonAdaptedTestResult} with the given test result details.
      */
     @JsonCreator
-    public JsonAdaptedTestResult(@JsonProperty("ownerNric") String ownerNric, @JsonProperty("date") String testDate,
+    public JsonAdaptedTestResult(@JsonProperty("patientNric") String patientNric, @JsonProperty("date") String testDate,
                                  @JsonProperty("medicalTest") String medicalTest,
                                  @JsonProperty("result") String result) {
 
-        this.ownerNric = ownerNric;
+        this.patientNric = patientNric;
         this.testDate = testDate;
         this.medicalTest = medicalTest;
         this.result = result;
@@ -40,7 +40,7 @@ class JsonAdaptedTestResult {
      * Converts a given {@code TestResult} into this class for Jackson use.
      */
     public JsonAdaptedTestResult(TestResult source) {
-        ownerNric = source.getOwnerNric().value;
+        patientNric = source.getPatientNric().value;
         testDate = source.getTestDate().toString();
         medicalTest = source.getMedicalTest().value;
         result = source.getResult().value;
@@ -52,13 +52,13 @@ class JsonAdaptedTestResult {
      * @throws IllegalValueException if there were any data constraints violated in the adapted test result.
      */
     public TestResult toModelType() throws IllegalValueException {
-        if (ownerNric == null) {
+        if (patientNric == null) {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Nric.class.getSimpleName()));
         }
-        if (!Nric.isValidNric(ownerNric)) {
+        if (!Nric.isValidNric(patientNric)) {
             throw new IllegalValueException(Name.MESSAGE_CONSTRAINTS);
         }
-        final Nric modelOwnerNric = new Nric(ownerNric);
+        final Nric modelPatientNric = new Nric(patientNric);
 
         if (testDate == null) {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
@@ -86,6 +86,6 @@ class JsonAdaptedTestResult {
         }
         final Result modelResult = new Result(result);
 
-        return new TestResult(modelOwnerNric, modelDate, modelMedicalTest, modelResult);
+        return new TestResult(modelPatientNric, modelDate, modelMedicalTest, modelResult);
     }
 }


### PR DESCRIPTION
This PR extends a new feature to delete a test result in MedBook 📕  and closes #30 

## New ✨
- MedBook now support the deletion of past test result with information about the patient it belongs to, the test taken, the date it was taken and the results of the test.

## Developer Note 🗒
- `DeleteTestResultCommand` command is a standalone command rather than extending from `DeleteCommand` for ease of integration in the future. Other commands with adding functionality can be extended from `DeleteCommand` at one go during the integration phase.