### PR TITLE
Add view all medical details when NRIC not specified + fix saving bug

### DIFF
--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -11,6 +11,7 @@ public class Messages {
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
     public static final String MESSAGE_CONTACTS_LISTED_OVERVIEW = "%1$d contacts listed! Belongs to: %2$s";
     public static final String MESSAGE_CONSULTATION_LISTED_OVERVIEW = "%1$d consultations listed! Belongs to: %2$s";
+    public static final String MESSAGE_MEDICALS_LISTED_NO_NRIC = "%1$d medical information listed!";
     public static final String MESSAGE_MEDICALS_LISTED_OVERVIEW = "%1$d medical information listed! Belongs to: %2$s";
     public static final String MESSAGE_PRESCRIPTIONS_LISTED_OVERVIEW = "%1$d prescription listed! Belongs to: %2$s";
     public static final String MESSAGE_INVALID_CONTACT_DISPLAYED_INDEX =

--- a/src/main/java/seedu/address/logic/commands/medical/ViewMedicalCommand.java
+++ b/src/main/java/seedu/address/logic/commands/medical/ViewMedicalCommand.java
@@ -31,7 +31,6 @@ public class ViewMedicalCommand extends Command {
      * Creates an ViewMedicalCommand to view the medical information of specified {@code Patient}
      */
     public ViewMedicalCommand(Nric nric) {
-        requireNonNull(nric);
         this.nric = nric;
     }
 
@@ -39,15 +38,23 @@ public class ViewMedicalCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-        model.updateFilteredMedicalList(new MedicalWithNricPredicate(nric));
 
-        if (!model.hasPerson(new NricPredicate(nric))) {
-            throw new CommandException(MESSAGE_MISSING_PATIENT);
+
+        if (nric == null) { // No nric specified, display all medical information
+            model.updateFilteredMedicalList(Model.PREDICATE_SHOW_ALL_MEDICALS);
+            return new CommandResult(
+                    String.format(Messages.MESSAGE_MEDICALS_LISTED_NO_NRIC,
+                            model.getFilteredMedicalList().size()),
+                    COMMAND_TYPE);
+        } else { // Nric specified, find and display medical details for patient with specifed nric
+            model.updateFilteredMedicalList(new MedicalWithNricPredicate(nric));
+            if (!model.hasPerson(new NricPredicate(nric))) {
+                throw new CommandException(MESSAGE_MISSING_PATIENT);
+            }
+            return new CommandResult(
+                    String.format(Messages.MESSAGE_MEDICALS_LISTED_OVERVIEW,
+                            model.getFilteredMedicalList().size(), nric),
+                    COMMAND_TYPE);
         }
-
-        return new CommandResult(
-                String.format(Messages.MESSAGE_MEDICALS_LISTED_OVERVIEW,
-                        model.getFilteredMedicalList().size(), nric),
-                COMMAND_TYPE);
     }
 }

--- a/src/main/java/seedu/address/logic/parser/medical/ViewMedicalCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/medical/ViewMedicalCommandParser.java
@@ -26,13 +26,17 @@ public class ViewMedicalCommandParser {
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_TYPE, PREFIX_NRIC);
 
-        if (!arePrefixesPresent(argMultimap, PREFIX_TYPE, PREFIX_NRIC)
+        if (!arePrefixesPresent(argMultimap, PREFIX_TYPE)
                 || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                     ViewMedicalCommand.MESSAGE_USAGE));
         }
 
-        Nric nric = ParserUtil.parseNric(argMultimap.getValue(PREFIX_NRIC).get());
+        Nric nric = null;
+
+        if (arePrefixesPresent(argMultimap, PREFIX_NRIC)) {
+            nric = ParserUtil.parseNric(argMultimap.getValue(PREFIX_NRIC).get());
+        }
 
         return new ViewMedicalCommand(nric);
     }

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -76,6 +76,7 @@ public class AddressBook implements ReadOnlyAddressBook {
         requireNonNull(newData);
         setPersons(newData.getPersonList());
         setContacts(newData.getContactList());
+        setMedicals(newData.getMedicalList());
         setConsultations(newData.getConsultationList());
         setPrescriptions(newData.getPrescriptionList());
         setTestResults(newData.getTestResultList());
@@ -352,6 +353,10 @@ public class AddressBook implements ReadOnlyAddressBook {
     public void setMedicals(Medical target, Medical editedMedical) {
         requireNonNull(editedMedical);
         medicals.setMedical(target, editedMedical);
+    }
+
+    public void setMedicals(List<Medical> medicals) {
+        this.medicals.setMedicals(medicals);
     }
 
     /**

--- a/src/main/java/seedu/address/model/medical/UniqueMedicalList.java
+++ b/src/main/java/seedu/address/model/medical/UniqueMedicalList.java
@@ -97,4 +97,17 @@ public class UniqueMedicalList implements Iterable<Medical> {
         }
         return true;
     }
+
+    /**
+     * Replaces the contents of this list with {@code medicals}.
+     * {@code medicals} must not contain duplicate medicals.
+     */
+    public void setMedicals(List<Medical> medicals) {
+        requireAllNonNull(medicals);
+        if (!medicalAreUnique(medicals)) {
+            throw new DuplicateMedicalException();
+        }
+
+        internalList.setAll(medicals);
+    }
 }

--- a/src/main/java/seedu/address/storage/JsonSerializableAddressBook.java
+++ b/src/main/java/seedu/address/storage/JsonSerializableAddressBook.java
@@ -26,7 +26,8 @@ class JsonSerializableAddressBook {
 
     public static final String MESSAGE_DUPLICATE_PERSON = "Persons list contains duplicate person(s).";
     public static final String MESSAGE_DUPLICATE_CONTACT = "Contact list contains duplicate person(s).";
-
+    public static final String MESSAGE_DUPLICATE_MEDICAL =
+            "Medical information list contains duplicate medical details.";
     public static final String MESSAGE_DUPLICATE_CONSULTATION = "Consultation list contains duplicate consultation(s).";
     public static final String MESSAGE_DUPLICATE_PRESCRIPTION = "Prescription list contains duplicate person(s).";
     public static final String MESSAGE_DUPLICATE_TEST_RESULT = "Test result list contains duplicate test(s).";
@@ -79,8 +80,6 @@ class JsonSerializableAddressBook {
                 .collect(Collectors.toList()));
         consultations.addAll(source.getConsultationList().stream().map(
                                 JsonAdaptedConsultation::new).collect(Collectors.toList()));
-        prescriptions.addAll(source.getPrescriptionList().stream().map(
-                JsonAdaptedPrescription::new).collect(Collectors.toList()));
         testResults.addAll(source.getTestResultList().stream().map(JsonAdaptedTestResult::new)
                 .collect(Collectors.toList()));
     }
@@ -109,7 +108,7 @@ class JsonSerializableAddressBook {
         for (JsonAdaptedMedical jsonAdaptedMedical: medicals) {
             Medical medical = jsonAdaptedMedical.toModelType();
             if (addressBook.hasMedical(medical)) {
-                throw new IllegalValueException(MESSAGE_DUPLICATE_CONTACT);
+                throw new IllegalValueException(MESSAGE_DUPLICATE_MEDICAL);
             }
             addressBook.addMedical(medical);
         }

--- a/src/main/java/seedu/address/ui/medical/MedicalCard.java
+++ b/src/main/java/seedu/address/ui/medical/MedicalCard.java
@@ -16,6 +16,8 @@ public class MedicalCard extends UiPart<Region> {
     @FXML
     private HBox cardPane;
     @FXML
+    private Label index;
+    @FXML
     private Label nric;
     @FXML
     private Label age;
@@ -54,7 +56,8 @@ public class MedicalCard extends UiPart<Region> {
     public MedicalCard(Medical medical, int displayedIndex) {
         super(FXML);
         this.medical = null;
-        nric.setText(displayedIndex + ". ");
+        index.setText(displayedIndex + ". ");
+        nric.setText("Patient's NRIC: " + medical.getPatientNric().value);
         age.setText("Age: " + medical.getAge().value);
         bloodType.setText("Blood type: " + medical.getBloodType().value);
         medication.setText("Medication: " + medical.getMedication().value);

--- a/src/main/resources/view/medical/MedicalListCard.fxml
+++ b/src/main/resources/view/medical/MedicalListCard.fxml
@@ -24,8 +24,9 @@
                         <Region fx:constant="USE_PREF_SIZE" />
                     </minWidth>
                 </Label>
-                <Label fx:id="nric" text="\$first" styleClass="cell_big_label" />
+                <Label fx:id="index" text="\$first" styleClass="cell_big_label" />
             </HBox>
+            <Label fx:id="nric" styleClass="cell_small_label" text="\$nric" />
             <Label fx:id="age" styleClass="cell_small_label" text="\$age" />
             <Label fx:id="bloodType" styleClass="cell_small_label" text="\$bloodType" />
             <Label fx:id="medication" styleClass="cell_small_label" text="\$medication" />


### PR DESCRIPTION
Changes:
- When user does not specify NRIC, `t /medical` now displays all available medical details
- Fix bug in which saved medical information is reset when restarting MedBook