### PR TITLE
feat: Edit Test Result Command #88

### DIFF
--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -20,8 +20,7 @@ public class Messages {
             "The prescription index provided is invalid";
     public static final String MESSAGE_TEST_RESULTS_LISTED_OVERVIEW = "%1$d test results listed! Belongs to: %2$s";
     public static final String MESSAGE_DUPLICATE_CONSULTATION = "Duplicate consultation found!";
-    public static final String MESSAGE_INVALID_TEST_RESULT_DISPLAYED_INDEX =
-            "The test result index provided is invalid";
+    public static final String MESSAGE_INVALID_TEST_RESULT_INDEX = "The test result index provided is invalid";
     public static final String MESSAGE_INVALID_MEDICAL_INFORMATION_INDEX =
             "The medical information index provided is invalid";
 

--- a/src/main/java/seedu/address/logic/commands/CommandType.java
+++ b/src/main/java/seedu/address/logic/commands/CommandType.java
@@ -20,6 +20,7 @@ import seedu.address.logic.parser.prescription.DeletePrescriptionCommandParser;
 import seedu.address.logic.parser.prescription.ViewPrescriptionCommandParser;
 import seedu.address.logic.parser.testresult.AddTestResultCommandParser;
 import seedu.address.logic.parser.testresult.DeleteTestResultCommandParser;
+import seedu.address.logic.parser.testresult.EditTestResultCommandParser;
 import seedu.address.logic.parser.testresult.ViewTestResultCommandParser;
 
 
@@ -145,7 +146,7 @@ public enum CommandType {
         case PRESCRIPTION:
             throw new ParseException("To be implemented");
         case TEST:
-            throw new ParseException("To be implemented");
+            return new EditTestResultCommandParser().parse(arguments);
         default:
             return new EditCommandParser().parse(arguments);
         }

--- a/src/main/java/seedu/address/logic/commands/medical/EditMedicalCommand.java
+++ b/src/main/java/seedu/address/logic/commands/medical/EditMedicalCommand.java
@@ -73,10 +73,10 @@ public class EditMedicalCommand extends Command {
     private final EditMedicalDescriptor editMedicalDescriptor;
 
     /**
-     * @param index of the medical information in the filtered medical information list to edit
+     * @param targetIndex of the medical information in the filtered medical information list to edit
      * @param editMedicalDescriptor details to edit the medical information with
      */
-    public EditMedicalCommand(Index targetIndex, EditMedicalCommand.EditMedicalDescriptor editMedicalDescriptor) {
+    public EditMedicalCommand(Index targetIndex, EditMedicalDescriptor editMedicalDescriptor) {
         this.targetIndex = targetIndex;
         this.editMedicalDescriptor = editMedicalDescriptor;
     }

--- a/src/main/java/seedu/address/logic/commands/testresult/DeleteTestResultCommand.java
+++ b/src/main/java/seedu/address/logic/commands/testresult/DeleteTestResultCommand.java
@@ -40,7 +40,7 @@ public class DeleteTestResultCommand extends Command {
         List<TestResult> lastShownList = model.getFilteredTestResultList();
 
         if (targetIndex.getZeroBased() >= lastShownList.size()) {
-            throw new CommandException(Messages.MESSAGE_INVALID_TEST_RESULT_DISPLAYED_INDEX);
+            throw new CommandException(Messages.MESSAGE_INVALID_TEST_RESULT_INDEX);
         }
 
         TestResult testResultToDelete = lastShownList.get(targetIndex.getZeroBased());

--- a/src/main/java/seedu/address/logic/commands/testresult/EditTestResultCommand.java
+++ b/src/main/java/seedu/address/logic/commands/testresult/EditTestResultCommand.java
@@ -1,0 +1,174 @@
+package seedu.address.logic.commands.testresult;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.Command;
+import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.CommandType;
+import seedu.address.logic.commands.EditCommand;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.patient.Nric;
+import seedu.address.model.testresult.MedicalTest;
+import seedu.address.model.testresult.Result;
+import seedu.address.model.testresult.TestDate;
+import seedu.address.model.testresult.TestResult;
+
+import java.util.List;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.*;
+
+/**
+ * Edits the details of an existing test result information in MedBook.
+ */
+public class EditTestResultCommand extends Command {
+    public static final String COMMAND_WORD = "edit";
+    public static final CommandType COMMAND_TYPE = CommandType.TEST;
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Edits the details of the medical information identified "
+            + "by the index number used in the displayed test result information list. "
+            + "Existing values will be overwritten by the input values.\n"
+            + "Parameters: INDEX (must be a positive integer) "
+            + PREFIX_NRIC + "PATIENT_NRIC "
+            + PREFIX_TESTDATE + "TEST_DATE "
+            + PREFIX_MEDICALTEST + "MEDICAL_TEST "
+            + PREFIX_RESULT + "TEST_RESULT \n"
+            + "Example: " + COMMAND_WORD + " 1 "
+            + PREFIX_NRIC + "S1234567L "
+            + PREFIX_RESULT + "Brain damage";
+
+    public static final String MESSAGE_EDIT_TEST_RESULT_SUCCESS = "Edited Test Result Information: %1$s";
+
+    private final Index targetIndex;
+    private final EditTestResultDescriptor editTestResultDescriptor;
+
+    /**
+     * @param targetIndex of the test result information in the filtered test result information list to edit
+     * @param editTestResultDescriptor details to edit the test result information with
+     */
+    public EditTestResultCommand(Index targetIndex, EditTestResultDescriptor editTestResultDescriptor) {
+        this.targetIndex = targetIndex;
+        this.editTestResultDescriptor = editTestResultDescriptor;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<TestResult> lastShownList = model.getFilteredTestResultList();
+
+        if (targetIndex.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_TEST_RESULT_INDEX);
+        }
+
+        TestResult testResult = lastShownList.get(targetIndex.getZeroBased());
+        TestResult editedTestResult = createEditedTestResult(testResult, editTestResultDescriptor);
+        model.setTestResult(testResult, editedTestResult);
+
+        return new CommandResult(String.format(MESSAGE_EDIT_TEST_RESULT_SUCCESS, editedTestResult), COMMAND_TYPE);
+    }
+
+    private static TestResult createEditedTestResult(TestResult testResult,
+                                               EditTestResultDescriptor editTestResultDescriptor) {
+        assert testResult != null;
+
+        Nric updatedNric = editTestResultDescriptor.getNric().orElse(testResult.getPatientNric());
+        TestDate updatedTestDate = editTestResultDescriptor.getTestDate().orElse(testResult.getTestDate());
+        MedicalTest updatedMedicalTest =
+                editTestResultDescriptor.getMedicalTest().orElse(testResult.getMedicalTest());
+        Result updatedResult =
+                editTestResultDescriptor.getResult().orElse(testResult.getResult());
+
+        return new TestResult(updatedNric,
+                updatedTestDate,
+                updatedMedicalTest,
+                updatedResult
+        );
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof EditTestResultCommand // instanceof handles nulls
+                && targetIndex.equals(((EditTestResultCommand) other).targetIndex)); // state check
+    }
+
+    /**
+     * Stores the details to edit the test result information with. Each non-empty field value will replace the
+     * corresponding field value of the test result information.
+     */
+    public static class EditTestResultDescriptor {
+        private Nric nric;
+        private TestDate testDate;
+        private MedicalTest medicalTest;
+        private Result result;
+
+        public EditTestResultDescriptor() {}
+
+        /**
+         * Copy constructor.
+         * A defensive copy of {@code tags} is used internally.
+         */
+        public EditTestResultDescriptor(EditTestResultDescriptor toCopy) {
+            setNric(toCopy.nric);
+            setTestDate(toCopy.testDate);
+            setMedicalTest(toCopy.medicalTest);
+            setResult(toCopy.result);
+        }
+
+        public Optional<Nric> getNric() {
+            return Optional.ofNullable(nric);
+        }
+
+        public void setNric(Nric nric) {
+            this.nric = nric;
+        }
+
+        public Optional<TestDate> getTestDate() {
+            return Optional.ofNullable(testDate);
+        }
+
+        public void setTestDate(TestDate testDate) {
+            this.testDate = testDate;
+        }
+
+        public Optional<MedicalTest> getMedicalTest() {
+            return Optional.ofNullable(medicalTest);
+        }
+
+        public void setMedicalTest(MedicalTest medicalTest) {
+            this.medicalTest = medicalTest;
+        }
+
+        public Optional<Result> getResult() {
+            return Optional.ofNullable(result);
+        }
+
+        public void setResult(Result result) {
+            this.result = result;
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            // short circuit if same object
+            if (other == this) {
+                return true;
+            }
+
+            // instanceof handles nulls
+            if (!(other instanceof EditCommand.EditPersonDescriptor)) {
+                return false;
+            }
+
+            // state check
+            EditTestResultDescriptor e = (EditTestResultDescriptor) other;
+
+            return getNric().equals(e.getNric())
+                    && getTestDate().equals(e.getTestDate())
+                    && getMedicalTest().equals(e.getMedicalTest())
+                    && getResult().equals(e.getResult());
+        }
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/testresult/EditTestResultCommand.java
+++ b/src/main/java/seedu/address/logic/commands/testresult/EditTestResultCommand.java
@@ -1,5 +1,14 @@
 package seedu.address.logic.commands.testresult;
 
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_MEDICALTEST;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NRIC;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_RESULT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TESTDATE;
+
+import java.util.Optional;
+import java.util.List;
+
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.Command;
@@ -13,12 +22,6 @@ import seedu.address.model.testresult.MedicalTest;
 import seedu.address.model.testresult.Result;
 import seedu.address.model.testresult.TestDate;
 import seedu.address.model.testresult.TestResult;
-
-import java.util.List;
-import java.util.Optional;
-
-import static java.util.Objects.requireNonNull;
-import static seedu.address.logic.parser.CliSyntax.*;
 
 /**
  * Edits the details of an existing test result information in MedBook.

--- a/src/main/java/seedu/address/logic/commands/testresult/EditTestResultCommand.java
+++ b/src/main/java/seedu/address/logic/commands/testresult/EditTestResultCommand.java
@@ -6,8 +6,8 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_NRIC;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_RESULT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TESTDATE;
 
-import java.util.Optional;
 import java.util.List;
+import java.util.Optional;
 
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;

--- a/src/main/java/seedu/address/logic/parser/testresult/EditTestResultCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/testresult/EditTestResultCommandParser.java
@@ -1,16 +1,18 @@
 package seedu.address.logic.parser.testresult;
 
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_MEDICALTEST;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NRIC;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_RESULT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TESTDATE;
+
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.testresult.EditTestResultCommand;
 import seedu.address.logic.parser.ArgumentMultimap;
 import seedu.address.logic.parser.ArgumentTokenizer;
 import seedu.address.logic.parser.ParserUtil;
 import seedu.address.logic.parser.exceptions.ParseException;
-
-import static java.util.Objects.requireNonNull;
-import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.parser.CliSyntax.*;
-
 
 /**
  * Parses input arguments and creates a new EditTestResultCommand object

--- a/src/main/java/seedu/address/logic/parser/testresult/EditTestResultCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/testresult/EditTestResultCommandParser.java
@@ -1,0 +1,56 @@
+package seedu.address.logic.parser.testresult;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.testresult.EditTestResultCommand;
+import seedu.address.logic.parser.ArgumentMultimap;
+import seedu.address.logic.parser.ArgumentTokenizer;
+import seedu.address.logic.parser.ParserUtil;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.*;
+
+
+/**
+ * Parses input arguments and creates a new EditTestResultCommand object
+ */
+public class EditTestResultCommandParser {
+    /**
+     * Parses the given {@code String} of arguments in the context of the EditTestResultCommand
+     * and returns an EditTestResultCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public EditTestResultCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        try {
+            ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NRIC, PREFIX_TESTDATE,
+                    PREFIX_MEDICALTEST, PREFIX_RESULT);
+
+            Index index = ParserUtil.parseIndex(argMultimap.getPreamble());
+
+            EditTestResultCommand.EditTestResultDescriptor editTestResultDescriptor =
+                    new EditTestResultCommand.EditTestResultDescriptor();
+
+            if (argMultimap.getValue(PREFIX_NRIC).isPresent()) {
+                editTestResultDescriptor.setNric(ParserUtil.parseNric(argMultimap.getValue(PREFIX_NRIC).get()));
+            }
+            if (argMultimap.getValue(PREFIX_TESTDATE).isPresent()) {
+                editTestResultDescriptor.setTestDate(ParserUtil.parseTestDate(
+                        argMultimap.getValue(PREFIX_TESTDATE).get()));
+            }
+            if (argMultimap.getValue(PREFIX_MEDICALTEST).isPresent()) {
+                editTestResultDescriptor.setMedicalTest(ParserUtil.parseMedicalTest(
+                        argMultimap.getValue(PREFIX_MEDICALTEST).get()));
+            }
+            if (argMultimap.getValue(PREFIX_RESULT).isPresent()) {
+                editTestResultDescriptor.setResult(ParserUtil.parseResult(argMultimap.getValue(PREFIX_RESULT).get()));
+            }
+
+            return new EditTestResultCommand(index, editTestResultDescriptor);
+        } catch (ParseException pe) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditTestResultCommand.MESSAGE_USAGE), pe);
+        }
+    }
+}


### PR DESCRIPTION
This PR extends a new feature to edit a test result in MedBook 📕  and closes #88 

## New ✨
- MedBook now support the editing of past test result with information about the patient it belongs to, the test taken, the date it was taken and the results of the test.

## Developer Note 🗒
- `EditTestResultCommand` command is a standalone command rather than extending from `EditCommand` for ease of integration in the future. Other commands with adding functionality can be extended from `EditCommand` at one go during the integration phase.