### PR TITLE
feat: Find Test Result Command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -57,6 +57,7 @@ public class AddCommand extends Command {
         }
         model.addPerson(toAdd);
         CommandType.setViewCommandType(CommandType.DEFAULT);
+        ViewedNric.setViewedNric(null);
         return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd));
     }
 

--- a/src/main/java/seedu/address/logic/commands/CommandType.java
+++ b/src/main/java/seedu/address/logic/commands/CommandType.java
@@ -22,8 +22,8 @@ import seedu.address.logic.parser.prescription.DeletePrescriptionCommandParser;
 import seedu.address.logic.parser.prescription.ViewPrescriptionCommandParser;
 import seedu.address.logic.parser.testresult.AddTestResultCommandParser;
 import seedu.address.logic.parser.testresult.DeleteTestResultCommandParser;
-import seedu.address.logic.parser.testresult.FindTestResultCommandParser;
 import seedu.address.logic.parser.testresult.EditTestResultCommandParser;
+import seedu.address.logic.parser.testresult.FindTestResultCommandParser;
 import seedu.address.logic.parser.testresult.ViewTestResultCommandParser;
 
 public enum CommandType {

--- a/src/main/java/seedu/address/logic/commands/CommandType.java
+++ b/src/main/java/seedu/address/logic/commands/CommandType.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 
 import seedu.address.logic.parser.DeleteCommandParser;
 import seedu.address.logic.parser.EditCommandParser;
+import seedu.address.logic.parser.FindCommandParser;
 import seedu.address.logic.parser.consultations.AddConsultationCommandParser;
 import seedu.address.logic.parser.consultations.DeleteConsultationCommandParser;
 import seedu.address.logic.parser.consultations.EditConsultationCommandParser;
@@ -21,9 +22,9 @@ import seedu.address.logic.parser.prescription.DeletePrescriptionCommandParser;
 import seedu.address.logic.parser.prescription.ViewPrescriptionCommandParser;
 import seedu.address.logic.parser.testresult.AddTestResultCommandParser;
 import seedu.address.logic.parser.testresult.DeleteTestResultCommandParser;
+import seedu.address.logic.parser.testresult.FindTestResultCommandParser;
 import seedu.address.logic.parser.testresult.EditTestResultCommandParser;
 import seedu.address.logic.parser.testresult.ViewTestResultCommandParser;
-
 
 public enum CommandType {
     DEFAULT, CONTACT, MEDICAL, CONSULTATION, PRESCRIPTION, TEST;
@@ -31,6 +32,7 @@ public enum CommandType {
     public static final String MESSAGE_CONSTRAINTS = "Command type should be either contact, medical, "
             + "consultation, prescription or test";
     private static CommandType viewCommandType = DEFAULT;
+
     private static String getFirstPrefixType(String text) {
         int index = text.indexOf(' ');
         if (index > -1) { // Check if there is more than one word.
@@ -174,6 +176,30 @@ public enum CommandType {
             return new DeleteTestResultCommandParser().parse(arguments);
         default:
             return new DeleteCommandParser().parse(arguments);
+        }
+    }
+
+    /**
+     * Returns command related to finding information of patients in MedBook.
+     *
+     * @param arguments user input arguments
+     * @return the command based on the user input
+     */
+    public static Command parseFindCommandType(String arguments) throws ParseException {
+        requireNonNull(arguments);
+        switch (viewCommandType) {
+        case CONTACT:
+            throw new ParseException("To be implemented");
+        case MEDICAL:
+            throw new ParseException("To be implemented");
+        case CONSULTATION:
+            throw new ParseException("To be implemented");
+        case PRESCRIPTION:
+            throw new ParseException("To be implemented");
+        case TEST:
+            return new FindTestResultCommandParser().parse(arguments);
+        default:
+            return new FindCommandParser().parse(arguments);
         }
     }
 }

--- a/src/main/java/seedu/address/logic/commands/ViewCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewCommand.java
@@ -20,6 +20,7 @@ public class ViewCommand extends Command {
         requireNonNull(model);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
         CommandType.setViewCommandType(CommandType.DEFAULT);
+        ViewedNric.setViewedNric(null);
         return new CommandResult(MESSAGE_SUCCESS);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/ViewedNric.java
+++ b/src/main/java/seedu/address/logic/commands/ViewedNric.java
@@ -1,0 +1,15 @@
+package seedu.address.logic.commands;
+
+import seedu.address.model.patient.Nric;
+
+public class ViewedNric {
+    private static Nric viewedNric = null;
+
+    public static Nric getViewedNric() {
+        return viewedNric;
+    }
+
+    public static void setViewedNric(Nric nric) {
+        viewedNric = nric;
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/testresult/FindTestResultCommand.java
+++ b/src/main/java/seedu/address/logic/commands/testresult/FindTestResultCommand.java
@@ -1,0 +1,48 @@
+package seedu.address.logic.commands.testresult;
+
+import static java.util.Objects.requireNonNull;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.logic.commands.Command;
+import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.CommandType;
+import seedu.address.logic.commands.ViewedNric;
+import seedu.address.model.Model;
+import seedu.address.model.testresult.TestResultContainsKeywordsPredicate;
+
+/**
+ * Finds and lists all test results in address book whose information contains any of the argument keywords.
+ * Keyword matching is case insensitive.
+ */
+public class FindTestResultCommand extends Command {
+
+    public static final String COMMAND_WORD = "find";
+    public static final CommandType COMMAND_TYPE = CommandType.TEST;
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Finds all test results whose information contain any of "
+            + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
+            + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
+            + "Example: " + COMMAND_WORD + " alice bob charlie";
+
+    private final TestResultContainsKeywordsPredicate predicate;
+
+    public FindTestResultCommand(TestResultContainsKeywordsPredicate predicate) {
+        this.predicate = predicate;
+    }
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+        model.updateFilteredTestResultList(predicate);
+        return new CommandResult(String.format(Messages.MESSAGE_TEST_RESULTS_LISTED_OVERVIEW,
+                        model.getFilteredTestResultList().size(), ViewedNric.getViewedNric().toString()), COMMAND_TYPE);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof FindTestResultCommand // instanceof handles nulls
+                && predicate.equals(((FindTestResultCommand) other).predicate)); // state check
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -12,6 +12,7 @@ import java.util.Set;
 import java.util.stream.Stream;
 
 import seedu.address.logic.commands.AddCommand;
+import seedu.address.logic.commands.ViewedNric;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.contact.Address;
 import seedu.address.model.contact.Email;
@@ -49,6 +50,7 @@ public class AddCommandParser implements Parser<AddCommand> {
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
 
         Patient patient = new Patient(nric, name, phone, email, address, tagList);
+        ViewedNric.setViewedNric(null);
 
         return new AddCommand(patient);
     }

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -4,8 +4,8 @@ import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.address.logic.commands.CommandType.parseAddCommandType;
 import static seedu.address.logic.commands.CommandType.parseDeleteCommandType;
-import static seedu.address.logic.commands.CommandType.parseFindCommandType;
 import static seedu.address.logic.commands.CommandType.parseEditCommandType;
+import static seedu.address.logic.commands.CommandType.parseFindCommandType;
 import static seedu.address.logic.commands.CommandType.parseViewCommandType;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TYPE;
 

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -4,6 +4,7 @@ import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.address.logic.commands.CommandType.parseAddCommandType;
 import static seedu.address.logic.commands.CommandType.parseDeleteCommandType;
+import static seedu.address.logic.commands.CommandType.parseFindCommandType;
 import static seedu.address.logic.commands.CommandType.parseEditCommandType;
 import static seedu.address.logic.commands.CommandType.parseViewCommandType;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TYPE;
@@ -67,7 +68,7 @@ public class AddressBookParser {
             return new ClearCommand();
 
         case FindCommand.COMMAND_WORD:
-            return new FindCommandParser().parse(arguments);
+            return parseFindCommandType(arguments);
 
         case ViewCommand.COMMAND_WORD:
             if (argMultimap.getValue(PREFIX_TYPE).isPresent()) {

--- a/src/main/java/seedu/address/logic/parser/consultations/AddConsultationCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/consultations/AddConsultationCommandParser.java
@@ -11,6 +11,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_TYPE;
 
 import java.util.stream.Stream;
 
+import seedu.address.logic.commands.ViewedNric;
 import seedu.address.logic.commands.consultation.AddConsultationCommand;
 import seedu.address.logic.parser.ArgumentMultimap;
 import seedu.address.logic.parser.ArgumentTokenizer;
@@ -50,7 +51,7 @@ public class AddConsultationCommandParser implements Parser<AddConsultationComma
         ConsultationDiagnosis diagnosis = ParserUtil.parseDiagnosis(argMultimap.getValue(PREFIX_DIAGNOSIS).get());
         ConsultationFee fee = ParserUtil.parseFee(argMultimap.getValue(PREFIX_FEE).get());
         ConsultationNotes notes = ParserUtil.parseNotes(argMultimap.getValue(PREFIX_NOTES).get());
-
+        ViewedNric.setViewedNric(ownerNric);
         Consultation consultation = new Consultation(ownerNric, date, time, diagnosis, fee, notes);
 
         return new AddConsultationCommand(ownerNric, consultation);

--- a/src/main/java/seedu/address/logic/parser/consultations/ViewConsultationCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/consultations/ViewConsultationCommandParser.java
@@ -6,6 +6,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_TYPE;
 
 import java.util.stream.Stream;
 
+import seedu.address.logic.commands.ViewedNric;
 import seedu.address.logic.commands.consultation.ViewConsultationCommand;
 import seedu.address.logic.parser.ArgumentMultimap;
 import seedu.address.logic.parser.ArgumentTokenizer;
@@ -31,6 +32,7 @@ public class ViewConsultationCommandParser {
         }
 
         Nric ownerNric = ParserUtil.parseNric(argMultimap.getValue(PREFIX_NRIC).get());
+        ViewedNric.setViewedNric(ownerNric);
 
         return new ViewConsultationCommand(ownerNric);
     }

--- a/src/main/java/seedu/address/logic/parser/contact/AddContactCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/contact/AddContactCommandParser.java
@@ -12,6 +12,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_TYPE;
 import java.util.Set;
 import java.util.stream.Stream;
 
+import seedu.address.logic.commands.ViewedNric;
 import seedu.address.logic.commands.contact.AddContactCommand;
 import seedu.address.logic.parser.ArgumentMultimap;
 import seedu.address.logic.parser.ArgumentTokenizer;
@@ -51,6 +52,7 @@ public class AddContactCommandParser implements Parser<AddContactCommand> {
         Address address = ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get());
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
 
+        ViewedNric.setViewedNric(ownerNric);
         Contact contact = new Contact(ownerNric, name, phone, email, address, tagList);
 
         return new AddContactCommand(ownerNric, contact);
@@ -60,7 +62,7 @@ public class AddContactCommandParser implements Parser<AddContactCommand> {
      * Returns true if none of the prefixes contains empty {@code Optional} values in the given
      * {@code ArgumentMultimap}.
      */
-    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+    public static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
         return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
     }
 

--- a/src/main/java/seedu/address/logic/parser/contact/ViewContactCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/contact/ViewContactCommandParser.java
@@ -6,6 +6,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_TYPE;
 
 import java.util.stream.Stream;
 
+import seedu.address.logic.commands.ViewedNric;
 import seedu.address.logic.commands.contact.ViewContactCommand;
 import seedu.address.logic.parser.ArgumentMultimap;
 import seedu.address.logic.parser.ArgumentTokenizer;
@@ -30,6 +31,7 @@ public class ViewContactCommandParser {
         }
 
         Nric ownerNric = ParserUtil.parseNric(argMultimap.getValue(PREFIX_NRIC).get());
+        ViewedNric.setViewedNric(ownerNric);
 
         return new ViewContactCommand(ownerNric);
     }

--- a/src/main/java/seedu/address/logic/parser/medical/AddMedicalCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/medical/AddMedicalCommandParser.java
@@ -17,6 +17,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_WEIGHT;
 
 import java.util.stream.Stream;
 
+import seedu.address.logic.commands.ViewedNric;
 import seedu.address.logic.commands.medical.AddMedicalCommand;
 import seedu.address.logic.parser.ArgumentMultimap;
 import seedu.address.logic.parser.ArgumentTokenizer;
@@ -88,9 +89,9 @@ public class AddMedicalCommandParser implements Parser<AddMedicalCommand> {
                 argMultimap.getValue(PREFIX_GENDER).orElse(EMPTY_PLACEHOLDER));
         Ethnicity ethnicity = ParserUtil.parseEthnicity(
                 argMultimap.getValue(PREFIX_ETHNICITY).orElse(EMPTY_PLACEHOLDER));
-
         Medical medical = new Medical(patientNric, age, bloodtype, medication, height, weight, illnesses, surgeries,
                 familyHistory, immunizationHistory, gender, ethnicity);
+        ViewedNric.setViewedNric(patientNric);
 
         return new AddMedicalCommand(patientNric, medical);
     }

--- a/src/main/java/seedu/address/logic/parser/medical/ViewMedicalCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/medical/ViewMedicalCommandParser.java
@@ -6,6 +6,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_TYPE;
 
 import java.util.stream.Stream;
 
+import seedu.address.logic.commands.ViewedNric;
 import seedu.address.logic.commands.medical.ViewMedicalCommand;
 import seedu.address.logic.parser.ArgumentMultimap;
 import seedu.address.logic.parser.ArgumentTokenizer;
@@ -37,6 +38,7 @@ public class ViewMedicalCommandParser {
         if (arePrefixesPresent(argMultimap, PREFIX_NRIC)) {
             nric = ParserUtil.parseNric(argMultimap.getValue(PREFIX_NRIC).get());
         }
+        ViewedNric.setViewedNric(nric);
 
         return new ViewMedicalCommand(nric);
     }

--- a/src/main/java/seedu/address/logic/parser/prescription/AddPrescriptionCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/prescription/AddPrescriptionCommandParser.java
@@ -9,6 +9,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_TYPE;
 
 import java.util.stream.Stream;
 
+import seedu.address.logic.commands.ViewedNric;
 import seedu.address.logic.commands.prescription.AddPrescriptionCommand;
 import seedu.address.logic.parser.ArgumentMultimap;
 import seedu.address.logic.parser.ArgumentTokenizer;
@@ -47,6 +48,8 @@ public class AddPrescriptionCommandParser implements Parser<AddPrescriptionComma
         Instruction instruction = ParserUtil.parseInstruction(argMultimap.getValue(PREFIX_INSTRUCTION).get());
 
         Prescription prescription = new Prescription(nric, drugName, date, instruction);
+
+        ViewedNric.setViewedNric(nric);
 
         return new AddPrescriptionCommand(nric, prescription);
     }

--- a/src/main/java/seedu/address/logic/parser/prescription/ViewPrescriptionCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/prescription/ViewPrescriptionCommandParser.java
@@ -6,6 +6,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_TYPE;
 
 import java.util.stream.Stream;
 
+import seedu.address.logic.commands.ViewedNric;
 import seedu.address.logic.commands.prescription.ViewPrescriptionCommand;
 import seedu.address.logic.parser.ArgumentMultimap;
 import seedu.address.logic.parser.ArgumentTokenizer;
@@ -33,6 +34,7 @@ public class ViewPrescriptionCommandParser {
         }
 
         Nric nric = ParserUtil.parseNric(argMultimap.getValue(PREFIX_NRIC).get());
+        ViewedNric.setViewedNric(nric);
 
         return new ViewPrescriptionCommand(nric);
     }

--- a/src/main/java/seedu/address/logic/parser/testresult/AddTestResultCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/testresult/AddTestResultCommandParser.java
@@ -9,6 +9,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_TYPE;
 
 import java.util.stream.Stream;
 
+import seedu.address.logic.commands.ViewedNric;
 import seedu.address.logic.commands.testresult.AddTestResultCommand;
 import seedu.address.logic.parser.ArgumentMultimap;
 import seedu.address.logic.parser.ArgumentTokenizer;
@@ -39,14 +40,15 @@ public class AddTestResultCommandParser implements Parser<AddTestResultCommand> 
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddTestResultCommand.MESSAGE_USAGE));
         }
 
-        Nric ownerNric = ParserUtil.parseNric(argMultimap.getValue(PREFIX_NRIC).get());
+        Nric patientNric = ParserUtil.parseNric(argMultimap.getValue(PREFIX_NRIC).get());
         TestDate testDate = ParserUtil.parseTestDate(argMultimap.getValue(PREFIX_TESTDATE).get());
         MedicalTest medicalTest = ParserUtil.parseMedicalTest(argMultimap.getValue(PREFIX_MEDICALTEST).get());
         Result result = ParserUtil.parseResult(argMultimap.getValue(PREFIX_RESULT).get());
 
-        TestResult testResult = new TestResult(ownerNric, testDate, medicalTest, result);
+        TestResult testResult = new TestResult(patientNric, testDate, medicalTest, result);
+        ViewedNric.setViewedNric(patientNric);
 
-        return new AddTestResultCommand(ownerNric, testResult);
+        return new AddTestResultCommand(patientNric, testResult);
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/testresult/FindTestResultCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/testresult/FindTestResultCommandParser.java
@@ -1,0 +1,34 @@
+package seedu.address.logic.parser.testresult;
+
+import seedu.address.logic.commands.testresult.FindTestResultCommand;
+import seedu.address.logic.parser.Parser;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.testresult.TestResultContainsKeywordsPredicate;
+
+import java.util.Arrays;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+/**
+ * Parses input arguments and creates a new FindTestResultCommand object
+ */
+public class FindTestResultCommandParser implements Parser<FindTestResultCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the FindTestResultCommand
+     * and returns a FindTestResultCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public FindTestResultCommand parse(String args) throws ParseException {
+        String trimmedArgs = args.trim();
+        if (trimmedArgs.isEmpty()) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindTestResultCommand.MESSAGE_USAGE));
+        }
+
+        String[] nameKeywords = trimmedArgs.split("\\s+");
+
+        return new FindTestResultCommand(new TestResultContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
+    }
+
+}

--- a/src/main/java/seedu/address/logic/parser/testresult/FindTestResultCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/testresult/FindTestResultCommandParser.java
@@ -1,13 +1,13 @@
 package seedu.address.logic.parser.testresult;
 
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import java.util.Arrays;
+
 import seedu.address.logic.commands.testresult.FindTestResultCommand;
 import seedu.address.logic.parser.Parser;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.testresult.TestResultContainsKeywordsPredicate;
-
-import java.util.Arrays;
-
-import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 /**
  * Parses input arguments and creates a new FindTestResultCommand object

--- a/src/main/java/seedu/address/logic/parser/testresult/ViewTestResultCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/testresult/ViewTestResultCommandParser.java
@@ -6,6 +6,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_TYPE;
 
 import java.util.stream.Stream;
 
+import seedu.address.logic.commands.ViewedNric;
 import seedu.address.logic.commands.testresult.ViewTestResultCommand;
 import seedu.address.logic.parser.ArgumentMultimap;
 import seedu.address.logic.parser.ArgumentTokenizer;
@@ -31,9 +32,10 @@ public class ViewTestResultCommandParser {
                     ViewTestResultCommand.MESSAGE_USAGE));
         }
 
-        Nric ownerNric = ParserUtil.parseNric(argMultimap.getValue(PREFIX_NRIC).get());
+        Nric patientNric = ParserUtil.parseNric(argMultimap.getValue(PREFIX_NRIC).get());
+        ViewedNric.setViewedNric(patientNric);
 
-        return new ViewTestResultCommand(ownerNric);
+        return new ViewTestResultCommand(patientNric);
     }
 
     /**

--- a/src/main/java/seedu/address/model/testresult/TestResultContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/testresult/TestResultContainsKeywordsPredicate.java
@@ -1,0 +1,38 @@
+package seedu.address.model.testresult;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import seedu.address.commons.util.StringUtil;
+import seedu.address.logic.commands.ViewedNric;
+
+/**
+ * Tests that a {@code Person}'s {@code TestResult} matches any of the keywords given.
+ */
+public class TestResultContainsKeywordsPredicate implements Predicate<TestResult> {
+    private final List<String> keywords;
+
+    public TestResultContainsKeywordsPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(TestResult testResult) {
+        return StringUtil.containsWordIgnoreCase(testResult.getPatientNric().toString(),
+                    ViewedNric.getViewedNric().toString())
+                && (keywords.stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(testResult.getTestDate().toString(), keyword))
+                || keywords.stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(testResult.getMedicalTest().toString(), keyword))
+                || keywords.stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(testResult.getResult().toString(), keyword)));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof TestResultContainsKeywordsPredicate // instanceof handles nulls
+                && keywords.equals(((TestResultContainsKeywordsPredicate) other).keywords)); // state check
+    }
+
+}


### PR DESCRIPTION
This PR extends a new feature to find a test result containing the given keywords in MedBook 📕 

## New ✨
- MedBook now support the finding of past test result with information containing the given keywords.

## Developer Note 🗒
- `FindTestResultCommand` command is a standalone command rather than extending from `FindCommand` for ease of integration in the future. Other commands with adding functionality can be extended from `FindCommand` at one go during the integration phase.