### PR TITLE
feat: Find Command #100

### DIFF
--- a/src/main/java/seedu/address/logic/commands/CommandType.java
+++ b/src/main/java/seedu/address/logic/commands/CommandType.java
@@ -2,7 +2,6 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
-import seedu.address.logic.commands.prescription.FindPrescriptionCommand;
 import seedu.address.logic.parser.DeleteCommandParser;
 import seedu.address.logic.parser.EditCommandParser;
 import seedu.address.logic.parser.FindCommandParser;
@@ -17,8 +16,13 @@ import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.logic.parser.medical.AddMedicalCommandParser;
 import seedu.address.logic.parser.medical.DeleteMedicalCommandParser;
 import seedu.address.logic.parser.medical.EditMedicalCommandParser;
+import seedu.address.logic.parser.medical.FindMedicalCommandParser;
 import seedu.address.logic.parser.medical.ViewMedicalCommandParser;
-import seedu.address.logic.parser.prescription.*;
+import seedu.address.logic.parser.prescription.AddPrescriptionCommandParser;
+import seedu.address.logic.parser.prescription.DeletePrescriptionCommandParser;
+import seedu.address.logic.parser.prescription.EditPrescriptionCommandParser;
+import seedu.address.logic.parser.prescription.FindPrescriptionCommandParser;
+import seedu.address.logic.parser.prescription.ViewPrescriptionCommandParser;
 import seedu.address.logic.parser.testresult.AddTestResultCommandParser;
 import seedu.address.logic.parser.testresult.DeleteTestResultCommandParser;
 import seedu.address.logic.parser.testresult.EditTestResultCommandParser;
@@ -190,7 +194,7 @@ public enum CommandType {
         case CONTACT:
             return new FindPrescriptionCommandParser().parse(arguments);
         case MEDICAL:
-            return new FindPrescriptionCommandParser().parse(arguments);
+            return new FindMedicalCommandParser().parse(arguments);
         case CONSULTATION:
             return new FindPrescriptionCommandParser().parse(arguments);
         case PRESCRIPTION:

--- a/src/main/java/seedu/address/logic/commands/CommandType.java
+++ b/src/main/java/seedu/address/logic/commands/CommandType.java
@@ -8,6 +8,7 @@ import seedu.address.logic.parser.FindCommandParser;
 import seedu.address.logic.parser.consultations.AddConsultationCommandParser;
 import seedu.address.logic.parser.consultations.DeleteConsultationCommandParser;
 import seedu.address.logic.parser.consultations.EditConsultationCommandParser;
+import seedu.address.logic.parser.consultations.FindConsultationCommandParser;
 import seedu.address.logic.parser.consultations.ViewConsultationCommandParser;
 import seedu.address.logic.parser.contact.AddContactCommandParser;
 import seedu.address.logic.parser.contact.DeleteContactCommandParser;
@@ -197,7 +198,7 @@ public enum CommandType {
         case MEDICAL:
             return new FindMedicalCommandParser().parse(arguments);
         case CONSULTATION:
-            return new FindPrescriptionCommandParser().parse(arguments);
+            return new FindConsultationCommandParser().parse(arguments);
         case PRESCRIPTION:
             return new FindPrescriptionCommandParser().parse(arguments);
         case TEST:

--- a/src/main/java/seedu/address/logic/commands/CommandType.java
+++ b/src/main/java/seedu/address/logic/commands/CommandType.java
@@ -2,6 +2,7 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
+import seedu.address.logic.commands.prescription.FindPrescriptionCommand;
 import seedu.address.logic.parser.DeleteCommandParser;
 import seedu.address.logic.parser.EditCommandParser;
 import seedu.address.logic.parser.FindCommandParser;
@@ -17,10 +18,7 @@ import seedu.address.logic.parser.medical.AddMedicalCommandParser;
 import seedu.address.logic.parser.medical.DeleteMedicalCommandParser;
 import seedu.address.logic.parser.medical.EditMedicalCommandParser;
 import seedu.address.logic.parser.medical.ViewMedicalCommandParser;
-import seedu.address.logic.parser.prescription.AddPrescriptionCommandParser;
-import seedu.address.logic.parser.prescription.DeletePrescriptionCommandParser;
-import seedu.address.logic.parser.prescription.EditPrescriptionCommandParser;
-import seedu.address.logic.parser.prescription.ViewPrescriptionCommandParser;
+import seedu.address.logic.parser.prescription.*;
 import seedu.address.logic.parser.testresult.AddTestResultCommandParser;
 import seedu.address.logic.parser.testresult.DeleteTestResultCommandParser;
 import seedu.address.logic.parser.testresult.EditTestResultCommandParser;
@@ -190,13 +188,13 @@ public enum CommandType {
         requireNonNull(arguments);
         switch (viewCommandType) {
         case CONTACT:
-            throw new ParseException("To be implemented");
+            return new FindPrescriptionCommandParser().parse(arguments);
         case MEDICAL:
-            throw new ParseException("To be implemented");
+            return new FindPrescriptionCommandParser().parse(arguments);
         case CONSULTATION:
-            throw new ParseException("To be implemented");
+            return new FindPrescriptionCommandParser().parse(arguments);
         case PRESCRIPTION:
-            throw new ParseException("To be implemented");
+            return new FindPrescriptionCommandParser().parse(arguments);
         case TEST:
             return new FindTestResultCommandParser().parse(arguments);
         default:

--- a/src/main/java/seedu/address/logic/commands/CommandType.java
+++ b/src/main/java/seedu/address/logic/commands/CommandType.java
@@ -11,6 +11,7 @@ import seedu.address.logic.parser.consultations.EditConsultationCommandParser;
 import seedu.address.logic.parser.consultations.ViewConsultationCommandParser;
 import seedu.address.logic.parser.contact.AddContactCommandParser;
 import seedu.address.logic.parser.contact.DeleteContactCommandParser;
+import seedu.address.logic.parser.contact.FindContactCommandParser;
 import seedu.address.logic.parser.contact.ViewContactCommandParser;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.logic.parser.medical.AddMedicalCommandParser;
@@ -192,7 +193,7 @@ public enum CommandType {
         requireNonNull(arguments);
         switch (viewCommandType) {
         case CONTACT:
-            return new FindPrescriptionCommandParser().parse(arguments);
+            return new FindContactCommandParser().parse(arguments);
         case MEDICAL:
             return new FindMedicalCommandParser().parse(arguments);
         case CONSULTATION:

--- a/src/main/java/seedu/address/logic/commands/consultation/FindConsultationCommand.java
+++ b/src/main/java/seedu/address/logic/commands/consultation/FindConsultationCommand.java
@@ -37,7 +37,7 @@ public class FindConsultationCommand extends Command {
         requireNonNull(model);
         model.updateFilteredConsultationList(predicate);
         return new CommandResult(String.format(Messages.MESSAGE_CONSULTATION_LISTED_OVERVIEW,
-                        model.getFilteredConsultationList().size(), ViewedNric.getViewedNric().toString()), COMMAND_TYPE);
+                model.getFilteredConsultationList().size(), ViewedNric.getViewedNric().toString()), COMMAND_TYPE);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/consultation/FindConsultationCommand.java
+++ b/src/main/java/seedu/address/logic/commands/consultation/FindConsultationCommand.java
@@ -1,0 +1,49 @@
+package seedu.address.logic.commands.consultation;
+
+import static java.util.Objects.requireNonNull;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.logic.commands.Command;
+import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.CommandType;
+import seedu.address.logic.commands.ViewedNric;
+import seedu.address.model.Model;
+import seedu.address.model.consultation.ConsultationContainsKeywordsPredicate;
+
+/**
+ * Finds and lists all consultations in the address book's current page whose information contains any of the argument
+ * keywords.
+ * Keyword matching is case insensitive.
+ */
+public class FindConsultationCommand extends Command {
+
+    public static final String COMMAND_WORD = "find";
+    public static final CommandType COMMAND_TYPE = CommandType.CONSULTATION;
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Finds all consultations in the current page whose information contain any of "
+            + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
+            + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
+            + "Example: " + COMMAND_WORD + " infection";
+
+    private final ConsultationContainsKeywordsPredicate predicate;
+
+    public FindConsultationCommand(ConsultationContainsKeywordsPredicate predicate) {
+        this.predicate = predicate;
+    }
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+        model.updateFilteredConsultationList(predicate);
+        return new CommandResult(String.format(Messages.MESSAGE_CONSULTATION_LISTED_OVERVIEW,
+                        model.getFilteredConsultationList().size(), ViewedNric.getViewedNric().toString()), COMMAND_TYPE);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof FindConsultationCommand // instanceof handles nulls
+                && predicate.equals(((FindConsultationCommand) other).predicate)); // state check
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/contact/FindContactCommand.java
+++ b/src/main/java/seedu/address/logic/commands/contact/FindContactCommand.java
@@ -1,0 +1,49 @@
+package seedu.address.logic.commands.contact;
+
+import static java.util.Objects.requireNonNull;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.logic.commands.Command;
+import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.CommandType;
+import seedu.address.logic.commands.ViewedNric;
+import seedu.address.model.Model;
+import seedu.address.model.contact.ContactContainsKeywordsPredicate;
+
+/**
+ * Finds and lists all contact records in the address book's current page whose information contains any of the argument
+ * keywords.
+ * Keyword matching is case insensitive.
+ */
+public class FindContactCommand extends Command {
+
+    public static final String COMMAND_WORD = "find";
+    public static final CommandType COMMAND_TYPE = CommandType.CONTACT;
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Finds all contact records in the current page whose information contain any of "
+            + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
+            + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
+            + "Example: " + COMMAND_WORD + " 88888888";
+
+    private final ContactContainsKeywordsPredicate predicate;
+
+    public FindContactCommand(ContactContainsKeywordsPredicate predicate) {
+        this.predicate = predicate;
+    }
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+        model.updateFilteredContactList(predicate);
+        return new CommandResult(String.format(Messages.MESSAGE_CONTACTS_LISTED_OVERVIEW,
+                        model.getFilteredContactList().size(), ViewedNric.getViewedNric().toString()), COMMAND_TYPE);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof FindContactCommand // instanceof handles nulls
+                && predicate.equals(((FindContactCommand) other).predicate)); // state check
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/medical/FindMedicalCommand.java
+++ b/src/main/java/seedu/address/logic/commands/medical/FindMedicalCommand.java
@@ -1,0 +1,49 @@
+package seedu.address.logic.commands.medical;
+
+import static java.util.Objects.requireNonNull;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.logic.commands.Command;
+import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.CommandType;
+import seedu.address.logic.commands.ViewedNric;
+import seedu.address.model.Model;
+import seedu.address.model.medical.MedicalContainsKeywordsPredicate;
+
+/**
+ * Finds and lists all medical records in the address book's current page whose information contains any of the argument
+ * keywords.
+ * Keyword matching is case insensitive.
+ */
+public class FindMedicalCommand extends Command {
+
+    public static final String COMMAND_WORD = "find";
+    public static final CommandType COMMAND_TYPE = CommandType.MEDICAL;
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Finds all medical records in the current page whose information contain any of "
+            + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
+            + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
+            + "Example: " + COMMAND_WORD + " diabetes";
+
+    private final MedicalContainsKeywordsPredicate predicate;
+
+    public FindMedicalCommand(MedicalContainsKeywordsPredicate predicate) {
+        this.predicate = predicate;
+    }
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+        model.updateFilteredMedicalList(predicate);
+        return new CommandResult(String.format(Messages.MESSAGE_MEDICALS_LISTED_OVERVIEW,
+                        model.getFilteredMedicalList().size(), ViewedNric.getViewedNric().toString()), COMMAND_TYPE);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof FindMedicalCommand // instanceof handles nulls
+                && predicate.equals(((FindMedicalCommand) other).predicate)); // state check
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/prescription/FindPrescriptionCommand.java
+++ b/src/main/java/seedu/address/logic/commands/prescription/FindPrescriptionCommand.java
@@ -37,7 +37,7 @@ public class FindPrescriptionCommand extends Command {
         requireNonNull(model);
         model.updateFilteredPrescriptionList(predicate);
         return new CommandResult(String.format(Messages.MESSAGE_PRESCRIPTIONS_LISTED_OVERVIEW,
-                        model.getFilteredPrescriptionList().size(), ViewedNric.getViewedNric().toString()), COMMAND_TYPE);
+                model.getFilteredPrescriptionList().size(), ViewedNric.getViewedNric().toString()), COMMAND_TYPE);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/prescription/FindPrescriptionCommand.java
+++ b/src/main/java/seedu/address/logic/commands/prescription/FindPrescriptionCommand.java
@@ -1,0 +1,49 @@
+package seedu.address.logic.commands.prescription;
+
+import static java.util.Objects.requireNonNull;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.logic.commands.Command;
+import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.CommandType;
+import seedu.address.logic.commands.ViewedNric;
+import seedu.address.model.Model;
+import seedu.address.model.prescription.PrescriptionContainsKeywordsPredicate;
+
+/**
+ * Finds and lists all prescriptions in the address book's current page whose information contains any of the argument
+ * keywords.
+ * Keyword matching is case insensitive.
+ */
+public class FindPrescriptionCommand extends Command {
+
+    public static final String COMMAND_WORD = "find";
+    public static final CommandType COMMAND_TYPE = CommandType.PRESCRIPTION;
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Finds all prescriptions in the current page whose information contain any of "
+            + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
+            + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
+            + "Example: " + COMMAND_WORD + " panadol";
+
+    private final PrescriptionContainsKeywordsPredicate predicate;
+
+    public FindPrescriptionCommand(PrescriptionContainsKeywordsPredicate predicate) {
+        this.predicate = predicate;
+    }
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+        model.updateFilteredPrescriptionList(predicate);
+        return new CommandResult(String.format(Messages.MESSAGE_PRESCRIPTIONS_LISTED_OVERVIEW,
+                        model.getFilteredPrescriptionList().size(), ViewedNric.getViewedNric().toString()), COMMAND_TYPE);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof FindPrescriptionCommand // instanceof handles nulls
+                && predicate.equals(((FindPrescriptionCommand) other).predicate)); // state check
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/testresult/FindTestResultCommand.java
+++ b/src/main/java/seedu/address/logic/commands/testresult/FindTestResultCommand.java
@@ -11,7 +11,8 @@ import seedu.address.model.Model;
 import seedu.address.model.testresult.TestResultContainsKeywordsPredicate;
 
 /**
- * Finds and lists all test results in address book whose information contains any of the argument keywords.
+ * Finds and lists all test results in address book in the current view whose information contains any of the argument
+ * keywords.
  * Keyword matching is case insensitive.
  */
 public class FindTestResultCommand extends Command {
@@ -20,10 +21,10 @@ public class FindTestResultCommand extends Command {
     public static final CommandType COMMAND_TYPE = CommandType.TEST;
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Finds all test results whose information contain any of "
+            + ": Finds all test results in the current page whose information contain any of "
             + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
             + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
-            + "Example: " + COMMAND_WORD + " alice bob charlie";
+            + "Example: " + COMMAND_WORD + " CT Scan";
 
     private final TestResultContainsKeywordsPredicate predicate;
 

--- a/src/main/java/seedu/address/logic/parser/consultations/FindConsultationCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/consultations/FindConsultationCommandParser.java
@@ -1,0 +1,34 @@
+package seedu.address.logic.parser.consultations;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import java.util.Arrays;
+
+import seedu.address.logic.commands.consultation.FindConsultationCommand;
+import seedu.address.logic.parser.Parser;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.consultation.ConsultationContainsKeywordsPredicate;
+
+/**
+ * Parses input arguments and creates a new FindConsultationCommand object
+ */
+public class FindConsultationCommandParser implements Parser<FindConsultationCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the FindTestResultCommand
+     * and returns a FindTestResultCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public FindConsultationCommand parse(String args) throws ParseException {
+        String trimmedArgs = args.trim();
+        if (trimmedArgs.isEmpty()) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindConsultationCommand.MESSAGE_USAGE));
+        }
+
+        String[] nameKeywords = trimmedArgs.split("\\s+");
+
+        return new FindConsultationCommand(new ConsultationContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
+    }
+
+}

--- a/src/main/java/seedu/address/logic/parser/contact/FindContactCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/contact/FindContactCommandParser.java
@@ -1,0 +1,34 @@
+package seedu.address.logic.parser.contact;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import java.util.Arrays;
+
+import seedu.address.logic.commands.contact.FindContactCommand;
+import seedu.address.logic.parser.Parser;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.contact.ContactContainsKeywordsPredicate;
+
+/**
+ * Parses input arguments and creates a new FindContactCommand object
+ */
+public class FindContactCommandParser implements Parser<FindContactCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the FindContactCommand
+     * and returns a FindContactCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public FindContactCommand parse(String args) throws ParseException {
+        String trimmedArgs = args.trim();
+        if (trimmedArgs.isEmpty()) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindContactCommand.MESSAGE_USAGE));
+        }
+
+        String[] nameKeywords = trimmedArgs.split("\\s+");
+
+        return new FindContactCommand(new ContactContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
+    }
+
+}

--- a/src/main/java/seedu/address/logic/parser/medical/FindMedicalCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/medical/FindMedicalCommandParser.java
@@ -1,0 +1,34 @@
+package seedu.address.logic.parser.medical;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import java.util.Arrays;
+
+import seedu.address.logic.commands.medical.FindMedicalCommand;
+import seedu.address.logic.parser.Parser;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.medical.MedicalContainsKeywordsPredicate;
+
+/**
+ * Parses input arguments and creates a new FindMedicalCommand object
+ */
+public class FindMedicalCommandParser implements Parser<FindMedicalCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the FindMedicalCommand
+     * and returns a FindMedicalCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public FindMedicalCommand parse(String args) throws ParseException {
+        String trimmedArgs = args.trim();
+        if (trimmedArgs.isEmpty()) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindMedicalCommand.MESSAGE_USAGE));
+        }
+
+        String[] nameKeywords = trimmedArgs.split("\\s+");
+
+        return new FindMedicalCommand(new MedicalContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
+    }
+
+}

--- a/src/main/java/seedu/address/logic/parser/prescription/FindPrescriptionCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/prescription/FindPrescriptionCommandParser.java
@@ -1,0 +1,34 @@
+package seedu.address.logic.parser.prescription;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import java.util.Arrays;
+
+import seedu.address.logic.commands.prescription.FindPrescriptionCommand;
+import seedu.address.logic.parser.Parser;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.prescription.PrescriptionContainsKeywordsPredicate;
+
+/**
+ * Parses input arguments and creates a new FindPrescriptionCommand object
+ */
+public class FindPrescriptionCommandParser implements Parser<FindPrescriptionCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the FindPrescriptionCommand
+     * and returns a FindPrescriptionCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public FindPrescriptionCommand parse(String args) throws ParseException {
+        String trimmedArgs = args.trim();
+        if (trimmedArgs.isEmpty()) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindPrescriptionCommand.MESSAGE_USAGE));
+        }
+
+        String[] nameKeywords = trimmedArgs.split("\\s+");
+
+        return new FindPrescriptionCommand(new PrescriptionContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
+    }
+
+}

--- a/src/main/java/seedu/address/model/consultation/ConsultationContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/consultation/ConsultationContainsKeywordsPredicate.java
@@ -5,7 +5,6 @@ import java.util.function.Predicate;
 
 import seedu.address.commons.util.StringUtil;
 import seedu.address.logic.commands.ViewedNric;
-import seedu.address.model.prescription.Prescription;
 
 /**
  * Tests that a {@code Person}'s {@code Consultation} matches any of the keywords given.

--- a/src/main/java/seedu/address/model/consultation/ConsultationContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/consultation/ConsultationContainsKeywordsPredicate.java
@@ -1,0 +1,43 @@
+package seedu.address.model.consultation;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import seedu.address.commons.util.StringUtil;
+import seedu.address.logic.commands.ViewedNric;
+import seedu.address.model.prescription.Prescription;
+
+/**
+ * Tests that a {@code Person}'s {@code Consultation} matches any of the keywords given.
+ */
+public class ConsultationContainsKeywordsPredicate implements Predicate<Consultation> {
+    private final List<String> keywords;
+
+    public ConsultationContainsKeywordsPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(Consultation consultation) {
+        return StringUtil.containsWordIgnoreCase(consultation.getNric().toString(),
+                    ViewedNric.getViewedNric().toString())
+                && (keywords.stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(consultation.getDate().toString(), keyword))
+                || keywords.stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(consultation.getDiagnosis().toString(), keyword))
+                || keywords.stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(consultation.getFee().toString(), keyword))
+                || keywords.stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(consultation.getNotes().toString(), keyword))
+                || keywords.stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(consultation.getTime().toString(), keyword)));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof ConsultationContainsKeywordsPredicate // instanceof handles nulls
+                && keywords.equals(((ConsultationContainsKeywordsPredicate) other).keywords)); // state check
+    }
+
+}

--- a/src/main/java/seedu/address/model/contact/ContactContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/contact/ContactContainsKeywordsPredicate.java
@@ -1,0 +1,50 @@
+package seedu.address.model.contact;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import seedu.address.commons.util.StringUtil;
+import seedu.address.logic.commands.ViewedNric;
+import seedu.address.model.tag.Tag;
+
+/**
+ * Tests that a {@code Person}'s {@code Contact} matches any of the keywords given.
+ */
+public class ContactContainsKeywordsPredicate implements Predicate<Contact> {
+    private final List<String> keywords;
+
+    public ContactContainsKeywordsPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(Contact contact) {
+        return StringUtil.containsWordIgnoreCase(contact.getOwnerNric().toString(),
+                    ViewedNric.getViewedNric().toString())
+                && (keywords.stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(contact.getAddress().toString(), keyword))
+                || keywords.stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(contact.getEmail().toString(), keyword))
+                || keywords.stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(contact.getName().toString(), keyword))
+                || keywords.stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(contact.getPhone().toString(), keyword))
+                || keywords.stream()
+                .anyMatch(keyword -> {
+                    for (Tag tag : contact.getTags()) {
+                        if (StringUtil.containsWordIgnoreCase(tag.toString(), keyword)) {
+                            return true;
+                        }
+                    }
+                    return false;
+                }));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof ContactContainsKeywordsPredicate // instanceof handles nulls
+                && keywords.equals(((ContactContainsKeywordsPredicate) other).keywords)); // state check
+    }
+
+}

--- a/src/main/java/seedu/address/model/medical/MedicalContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/medical/MedicalContainsKeywordsPredicate.java
@@ -1,0 +1,55 @@
+package seedu.address.model.medical;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import seedu.address.commons.util.StringUtil;
+import seedu.address.logic.commands.ViewedNric;
+
+/**
+ * Tests that a {@code Person}'s {@code Medical} matches any of the keywords given.
+ */
+public class MedicalContainsKeywordsPredicate implements Predicate<Medical> {
+    private final List<String> keywords;
+
+    public MedicalContainsKeywordsPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(Medical medical) {
+        return StringUtil.containsWordIgnoreCase(medical.getPatientNric().toString(),
+                    ViewedNric.getViewedNric().toString())
+                && (keywords.stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(medical.getAge().toString(), keyword))
+                || keywords.stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(medical.getBloodType().toString(), keyword))
+                || keywords.stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(medical.getMedication().toString(), keyword))
+                || keywords.stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(medical.getEthnicity().toString(), keyword))
+                || keywords.stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(medical.getFamilyHistory().toString(), keyword))
+                || keywords.stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(medical.getGender().toString(), keyword))
+                || keywords.stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(medical.getHeight().toString(), keyword))
+                || keywords.stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(medical.getIllnesses().toString(), keyword))
+                || keywords.stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(medical.getImmunizationHistory().toString(),
+                        keyword))
+                || keywords.stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(medical.getSurgeries().toString(), keyword))
+                || keywords.stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(medical.getWeight().toString(), keyword)));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof MedicalContainsKeywordsPredicate // instanceof handles nulls
+                && keywords.equals(((MedicalContainsKeywordsPredicate) other).keywords)); // state check
+    }
+
+}

--- a/src/main/java/seedu/address/model/prescription/PrescriptionContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/prescription/PrescriptionContainsKeywordsPredicate.java
@@ -1,0 +1,38 @@
+package seedu.address.model.prescription;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import seedu.address.commons.util.StringUtil;
+import seedu.address.logic.commands.ViewedNric;
+
+/**
+ * Tests that a {@code Person}'s {@code Prescription} matches any of the keywords given.
+ */
+public class PrescriptionContainsKeywordsPredicate implements Predicate<Prescription> {
+    private final List<String> keywords;
+
+    public PrescriptionContainsKeywordsPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(Prescription prescription) {
+        return StringUtil.containsWordIgnoreCase(prescription.getPrescriptionTarget().toString(),
+                    ViewedNric.getViewedNric().toString())
+                && (keywords.stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(prescription.getPrescriptionDate().toString(), keyword))
+                || keywords.stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(prescription.getInstruction().toString(), keyword))
+                || keywords.stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(prescription.getDrugName().toString(), keyword)));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof PrescriptionContainsKeywordsPredicate // instanceof handles nulls
+                && keywords.equals(((PrescriptionContainsKeywordsPredicate) other).keywords)); // state check
+    }
+
+}

--- a/src/main/java/seedu/address/model/prescription/PrescriptionContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/prescription/PrescriptionContainsKeywordsPredicate.java
@@ -21,11 +21,14 @@ public class PrescriptionContainsKeywordsPredicate implements Predicate<Prescrip
         return StringUtil.containsWordIgnoreCase(prescription.getPrescriptionTarget().toString(),
                     ViewedNric.getViewedNric().toString())
                 && (keywords.stream()
-                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(prescription.getPrescriptionDate().toString(), keyword))
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(prescription.getPrescriptionDate().toString(),
+                        keyword))
                 || keywords.stream()
-                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(prescription.getInstruction().toString(), keyword))
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(prescription.getInstruction().toString(),
+                        keyword))
                 || keywords.stream()
-                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(prescription.getDrugName().toString(), keyword)));
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(prescription.getDrugName().toString(),
+                        keyword)));
     }
 
     @Override


### PR DESCRIPTION
This PR extends a new feature to find a test result containing the given keywords in MedBook 📕  and closes #100 

## New ✨
- MedBook now support the finding of contacts, prescriptions, consultations, medical information with information containing the given keywords.

## Developer Note 🗒
- `FindContactResultCommand`, `FindPrescriptionCommand`, `FindConsultationCommand` and `FindMedicalCommand`command are standalone commands rather than extending from `FindCommand` for ease of integration in the future. Other commands with adding functionality can be extended from `FindCommand` at one go during the integration phase.