### PR TITLE
feat: Edit contact and integrate all edit commands

### DIFF
--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -4,27 +4,39 @@ package seedu.address.commons.core;
  * Container for user visible messages.
  */
 public class Messages {
-
+    // General messages
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
-    public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
-    public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
+
+    // Patient related messages
+    public static final String MESSAGE_INVALID_PATIENT_DISPLAYED_INDEX = "The patient index provided is invalid";
+    public static final String MESSAGE_PATIENTS_LISTED_OVERVIEW = "%1$d patients listed!";
+
+    // Contact related messages
     public static final String MESSAGE_CONTACTS_LISTED_OVERVIEW = "%1$d contacts listed! Belongs to: %2$s";
-    public static final String MESSAGE_CONSULTATION_LISTED_OVERVIEW = "%1$d consultations listed! Belongs to: %2$s";
-    public static final String MESSAGE_MEDICALS_LISTED_NO_NRIC = "%1$d medical information listed!";
-    public static final String MESSAGE_MEDICALS_LISTED_OVERVIEW = "%1$d medical information listed! Belongs to: %2$s";
-    public static final String MESSAGE_PRESCRIPTIONS_LISTED_OVERVIEW = "%1$d prescription listed! Belongs to: %2$s";
     public static final String MESSAGE_INVALID_CONTACT_DISPLAYED_INDEX =
             "The contact index provided is invalid";
-    public static final String MESSAGE_INVALID_PRESCRIPTION_DISPLAYED_INDEX =
-            "The prescription index provided is invalid";
-    public static final String MESSAGE_TEST_RESULTS_LISTED_OVERVIEW = "%1$d test results listed! Belongs to: %2$s";
-    public static final String MESSAGE_DUPLICATE_CONSULTATION = "Duplicate consultation found!";
-    public static final String MESSAGE_INVALID_TEST_RESULT_INDEX = "The test result index provided is invalid";
-    public static final String MESSAGE_INVALID_MEDICAL_INFORMATION_INDEX =
-            "The medical information index provided is invalid";
+
+    // Consultation related messages
+    public static final String MESSAGE_CONSULTATION_LISTED_OVERVIEW = "%1$d consultations listed! Belongs to: %2$s";
     public static final String MESSAGE_INVALID_CONSULTATION_INDEX =
             "The consultation index provided is invalid";
 
+    // Medical related messages
+    public static final String MESSAGE_MEDICALS_LISTED_NO_NRIC = "%1$d medical information listed!";
+    public static final String MESSAGE_MEDICALS_LISTED_OVERVIEW = "%1$d medical information listed! Belongs to: %2$s";
+    public static final String MESSAGE_INVALID_MEDICAL_INFORMATION_INDEX =
+            "The medical information index provided is invalid";
+
+    // Prescription related messages
+    public static final String MESSAGE_PRESCRIPTIONS_LISTED_OVERVIEW = "%1$d prescription listed! Belongs to: %2$s";
+    public static final String MESSAGE_INVALID_PRESCRIPTION_DISPLAYED_INDEX =
+            "The prescription index provided is invalid";
+
+    // Test related messages
+    public static final String MESSAGE_TEST_RESULTS_LISTED_OVERVIEW = "%1$d test results listed! Belongs to: %2$s";
+    public static final String MESSAGE_INVALID_TEST_RESULT_INDEX = "The test result index provided is invalid";
+
+    // Summary related messages
     public static final String MESSAGE_SUMMARY_SHOWN = "Summary for patient with NRIC %1$s shown!";
 }

--- a/src/main/java/seedu/address/logic/commands/CommandType.java
+++ b/src/main/java/seedu/address/logic/commands/CommandType.java
@@ -12,6 +12,7 @@ import seedu.address.logic.parser.consultations.FindConsultationCommandParser;
 import seedu.address.logic.parser.consultations.ViewConsultationCommandParser;
 import seedu.address.logic.parser.contact.AddContactCommandParser;
 import seedu.address.logic.parser.contact.DeleteContactCommandParser;
+import seedu.address.logic.parser.contact.EditContactCommandParser;
 import seedu.address.logic.parser.contact.FindContactCommandParser;
 import seedu.address.logic.parser.contact.ViewContactCommandParser;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -146,7 +147,7 @@ public enum CommandType {
         requireNonNull(arguments);
         switch (viewCommandType) {
         case CONTACT:
-            throw new ParseException("To be implemented");
+            return new EditContactCommandParser().parse(arguments);
         case MEDICAL:
             return new EditMedicalCommandParser().parse(arguments);
         case CONSULTATION:

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -47,7 +47,7 @@ public class DeleteCommand extends Command {
         List<Patient> lastShownList = model.getFilteredPatientList();
 
         if (targetIndex.getZeroBased() >= lastShownList.size()) {
-            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+            throw new CommandException(Messages.MESSAGE_INVALID_PATIENT_DISPLAYED_INDEX);
         }
 
         Patient patientToDelete = lastShownList.get(targetIndex.getZeroBased());

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -38,7 +38,8 @@ public class EditCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the patient identified "
             + "by the index number used in the displayed patient list. "
             + "Existing values will be overwritten by the input values.\n"
-            + "Parameters: INDEX (must be a positive integer) "
+            + "Parameters: INDEX (must be a positive integer)\n"
+            + "NRIC FIELD CANNOT BE MODIFIED IN THE FUTURE - PLEASE DOUBLE CHECK.\n"
             + "[" + PREFIX_NRIC + "NRIC] "
             + "[" + PREFIX_NAME + "NAME] "
             + "[" + PREFIX_PHONE + "PHONE] "
@@ -52,6 +53,7 @@ public class EditCommand extends Command {
     public static final String MESSAGE_EDIT_PATIENT_SUCCESS = "Edited Patient: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
     public static final String MESSAGE_DUPLICATE_PATIENT = "This patient already exists in MedBook.";
+    public static final String MESSAGE_NRIC_EDIT_NOT_ALLOWED = "NRIC field cannot be modified.";
 
     private final Index index;
     private final EditPatientDescriptor editPatientDescriptor;
@@ -96,7 +98,7 @@ public class EditCommand extends Command {
     private static Patient createEditedPerson(Patient patientToEdit, EditPatientDescriptor editPatientDescriptor) {
         assert patientToEdit != null;
 
-        Nric updatedNric = editPatientDescriptor.getNric().orElse(patientToEdit.getNric());
+        Nric updatedNric = patientToEdit.getNric();
         Name updatedName = editPatientDescriptor.getName().orElse(patientToEdit.getName());
         Phone updatedPhone = editPatientDescriptor.getPhone().orElse(patientToEdit.getPhone());
         Email updatedEmail = editPatientDescriptor.getEmail().orElse(patientToEdit.getEmail());
@@ -129,7 +131,6 @@ public class EditCommand extends Command {
      * corresponding field value of the person.
      */
     public static class EditPatientDescriptor {
-        private Nric nric;
         private Name name;
         private Phone phone;
         private Email email;
@@ -143,7 +144,6 @@ public class EditCommand extends Command {
          * A defensive copy of {@code tags} is used internally.
          */
         public EditPatientDescriptor(EditPatientDescriptor toCopy) {
-            setNric(toCopy.nric);
             setName(toCopy.name);
             setPhone(toCopy.phone);
             setEmail(toCopy.email);
@@ -164,14 +164,6 @@ public class EditCommand extends Command {
 
         public Optional<Name> getName() {
             return Optional.ofNullable(name);
-        }
-
-        public void setNric(Nric nric) {
-            this.nric = nric;
-        }
-
-        public Optional<Nric> getNric() {
-            return Optional.ofNullable(nric);
         }
 
         public void setPhone(Phone phone) {
@@ -231,7 +223,6 @@ public class EditCommand extends Command {
             EditPatientDescriptor e = (EditPatientDescriptor) other;
 
             return getName().equals(e.getName())
-                    && getNric().equals(e.getNric())
                     && getPhone().equals(e.getPhone())
                     && getEmail().equals(e.getEmail())
                     && getAddress().equals(e.getAddress())

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -4,7 +4,6 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NRIC;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
@@ -40,7 +39,6 @@ public class EditCommand extends Command {
             + "Existing values will be overwritten by the input values.\n"
             + "Parameters: INDEX (must be a positive integer)\n"
             + "NRIC FIELD CANNOT BE MODIFIED IN THE FUTURE - PLEASE DOUBLE CHECK.\n"
-            + "[" + PREFIX_NRIC + "NRIC] "
             + "[" + PREFIX_NAME + "NAME] "
             + "[" + PREFIX_PHONE + "PHONE] "
             + "[" + PREFIX_EMAIL + "EMAIL] "
@@ -98,7 +96,8 @@ public class EditCommand extends Command {
     private static Patient createEditedPerson(Patient patientToEdit, EditPatientDescriptor editPatientDescriptor) {
         assert patientToEdit != null;
 
-        Nric updatedNric = patientToEdit.getNric();
+        // Nric editing field is retained here for code testing.
+        Nric updatedNric = editPatientDescriptor.getNric().orElse(patientToEdit.getNric());
         Name updatedName = editPatientDescriptor.getName().orElse(patientToEdit.getName());
         Phone updatedPhone = editPatientDescriptor.getPhone().orElse(patientToEdit.getPhone());
         Email updatedEmail = editPatientDescriptor.getEmail().orElse(patientToEdit.getEmail());
@@ -131,6 +130,7 @@ public class EditCommand extends Command {
      * corresponding field value of the person.
      */
     public static class EditPatientDescriptor {
+        private Nric nric;
         private Name name;
         private Phone phone;
         private Email email;
@@ -144,6 +144,7 @@ public class EditCommand extends Command {
          * A defensive copy of {@code tags} is used internally.
          */
         public EditPatientDescriptor(EditPatientDescriptor toCopy) {
+            setNric(toCopy.nric);
             setName(toCopy.name);
             setPhone(toCopy.phone);
             setEmail(toCopy.email);
@@ -155,7 +156,15 @@ public class EditCommand extends Command {
          * Returns true if at least one field is edited.
          */
         public boolean isAnyFieldEdited() {
-            return CollectionUtil.isAnyNonNull(name, phone, email, address, tags);
+            return CollectionUtil.isAnyNonNull(nric, name, phone, email, address, tags);
+        }
+
+        public void setNric(Nric nric) {
+            this.nric = nric;
+        }
+
+        public Optional<Nric> getNric() {
+            return Optional.ofNullable(nric);
         }
 
         public void setName(Name name) {
@@ -223,6 +232,7 @@ public class EditCommand extends Command {
             EditPatientDescriptor e = (EditPatientDescriptor) other;
 
             return getName().equals(e.getName())
+                    && getNric().equals(e.getNric())
                     && getPhone().equals(e.getPhone())
                     && getEmail().equals(e.getEmail())
                     && getAddress().equals(e.getAddress())

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -29,14 +29,14 @@ import seedu.address.model.patient.Patient;
 import seedu.address.model.tag.Tag;
 
 /**
- * Edits the details of an existing person in the address book.
+ * Edits the details of an existing patient in the MedBook.
  */
 public class EditCommand extends Command {
 
     public static final String COMMAND_WORD = "edit";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the person identified "
-            + "by the index number used in the displayed person list. "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the patient identified "
+            + "by the index number used in the displayed patient list. "
             + "Existing values will be overwritten by the input values.\n"
             + "Parameters: INDEX (must be a positive integer) "
             + "[" + PREFIX_NRIC + "NRIC] "
@@ -49,23 +49,23 @@ public class EditCommand extends Command {
             + PREFIX_PHONE + "91234567 "
             + PREFIX_EMAIL + "johndoe@example.com";
 
-    public static final String MESSAGE_EDIT_PERSON_SUCCESS = "Edited Person: %1$s";
+    public static final String MESSAGE_EDIT_PATIENT_SUCCESS = "Edited Patient: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
-    public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the address book.";
+    public static final String MESSAGE_DUPLICATE_PATIENT = "This patient already exists in MedBook.";
 
     private final Index index;
-    private final EditPersonDescriptor editPersonDescriptor;
+    private final EditPatientDescriptor editPatientDescriptor;
 
     /**
-     * @param index of the person in the filtered person list to edit
-     * @param editPersonDescriptor details to edit the person with
+     * @param index of the patient in the filtered patient list to edit
+     * @param editPatientDescriptor details to edit the patient with
      */
-    public EditCommand(Index index, EditPersonDescriptor editPersonDescriptor) {
+    public EditCommand(Index index, EditPatientDescriptor editPatientDescriptor) {
         requireNonNull(index);
-        requireNonNull(editPersonDescriptor);
+        requireNonNull(editPatientDescriptor);
 
         this.index = index;
-        this.editPersonDescriptor = new EditPersonDescriptor(editPersonDescriptor);
+        this.editPatientDescriptor = new EditPatientDescriptor(editPatientDescriptor);
     }
 
     @Override
@@ -74,34 +74,34 @@ public class EditCommand extends Command {
         List<Patient> lastShownList = model.getFilteredPatientList();
 
         if (index.getZeroBased() >= lastShownList.size()) {
-            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+            throw new CommandException(Messages.MESSAGE_INVALID_PATIENT_DISPLAYED_INDEX);
         }
 
         Patient patientToEdit = lastShownList.get(index.getZeroBased());
-        Patient editedPatient = createEditedPerson(patientToEdit, editPersonDescriptor);
+        Patient editedPatient = createEditedPerson(patientToEdit, editPatientDescriptor);
 
         if (!patientToEdit.isSamePatient(editedPatient) && model.hasPatient(editedPatient)) {
-            throw new CommandException(MESSAGE_DUPLICATE_PERSON);
+            throw new CommandException(MESSAGE_DUPLICATE_PATIENT);
         }
 
         model.setPerson(patientToEdit, editedPatient);
         model.updateFilteredPatientList(PREDICATE_SHOW_ALL_PERSONS);
-        return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS, editedPatient));
+        return new CommandResult(String.format(MESSAGE_EDIT_PATIENT_SUCCESS, editedPatient));
     }
 
     /**
-     * Creates and returns a {@code Person} with the details of {@code personToEdit}
+     * Creates and returns a {@code Patient} with the details of {@code patientToEdit}
      * edited with {@code editPersonDescriptor}.
      */
-    private static Patient createEditedPerson(Patient patientToEdit, EditPersonDescriptor editPersonDescriptor) {
+    private static Patient createEditedPerson(Patient patientToEdit, EditPatientDescriptor editPatientDescriptor) {
         assert patientToEdit != null;
 
-        Nric updatedNric = editPersonDescriptor.getNric().orElse(patientToEdit.getNric());
-        Name updatedName = editPersonDescriptor.getName().orElse(patientToEdit.getName());
-        Phone updatedPhone = editPersonDescriptor.getPhone().orElse(patientToEdit.getPhone());
-        Email updatedEmail = editPersonDescriptor.getEmail().orElse(patientToEdit.getEmail());
-        Address updatedAddress = editPersonDescriptor.getAddress().orElse(patientToEdit.getAddress());
-        Set<Tag> updatedTags = editPersonDescriptor.getTags().orElse(patientToEdit.getTags());
+        Nric updatedNric = editPatientDescriptor.getNric().orElse(patientToEdit.getNric());
+        Name updatedName = editPatientDescriptor.getName().orElse(patientToEdit.getName());
+        Phone updatedPhone = editPatientDescriptor.getPhone().orElse(patientToEdit.getPhone());
+        Email updatedEmail = editPatientDescriptor.getEmail().orElse(patientToEdit.getEmail());
+        Address updatedAddress = editPatientDescriptor.getAddress().orElse(patientToEdit.getAddress());
+        Set<Tag> updatedTags = editPatientDescriptor.getTags().orElse(patientToEdit.getTags());
 
         return new Patient(updatedNric, updatedName, updatedPhone, updatedEmail, updatedAddress, updatedTags);
     }
@@ -121,14 +121,14 @@ public class EditCommand extends Command {
         // state check
         EditCommand e = (EditCommand) other;
         return index.equals(e.index)
-                && editPersonDescriptor.equals(e.editPersonDescriptor);
+                && editPatientDescriptor.equals(e.editPatientDescriptor);
     }
 
     /**
      * Stores the details to edit the person with. Each non-empty field value will replace the
      * corresponding field value of the person.
      */
-    public static class EditPersonDescriptor {
+    public static class EditPatientDescriptor {
         private Nric nric;
         private Name name;
         private Phone phone;
@@ -136,13 +136,13 @@ public class EditCommand extends Command {
         private Address address;
         private Set<Tag> tags;
 
-        public EditPersonDescriptor() {}
+        public EditPatientDescriptor() {}
 
         /**
          * Copy constructor.
          * A defensive copy of {@code tags} is used internally.
          */
-        public EditPersonDescriptor(EditPersonDescriptor toCopy) {
+        public EditPatientDescriptor(EditPatientDescriptor toCopy) {
             setNric(toCopy.nric);
             setName(toCopy.name);
             setPhone(toCopy.phone);
@@ -223,12 +223,12 @@ public class EditCommand extends Command {
             }
 
             // instanceof handles nulls
-            if (!(other instanceof EditPersonDescriptor)) {
+            if (!(other instanceof EditPatientDescriptor)) {
                 return false;
             }
 
             // state check
-            EditPersonDescriptor e = (EditPersonDescriptor) other;
+            EditPatientDescriptor e = (EditPatientDescriptor) other;
 
             return getName().equals(e.getName())
                     && getNric().equals(e.getNric())

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -30,7 +30,7 @@ public class FindCommand extends Command {
         requireNonNull(model);
         model.updateFilteredPatientList(predicate);
         return new CommandResult(
-                String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPatientList().size()));
+                String.format(Messages.MESSAGE_PATIENTS_LISTED_OVERVIEW, model.getFilteredPatientList().size()));
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/consultation/EditConsultationCommand.java
+++ b/src/main/java/seedu/address/logic/commands/consultation/EditConsultationCommand.java
@@ -52,7 +52,7 @@ public class EditConsultationCommand extends Command {
 
     public static final String MESSAGE_EDIT_TEST_RESULT_SUCCESS = "Edited Consultation Information: \n%1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
-    public static final String MESSAGE_DUPLICATE_CONTACT = "This contact already exists in MedBook.";
+    public static final String MESSAGE_DUPLICATE_CONSULTATION = "This consultation already exists in MedBook.";
 
     private final Index targetIndex;
     private final EditConsultationDescriptor editConsultationDescriptor;
@@ -77,6 +77,11 @@ public class EditConsultationCommand extends Command {
 
         Consultation consultation = lastShownList.get(targetIndex.getZeroBased());
         Consultation editedConsultation = createEditedConsultation(consultation, editConsultationDescriptor);
+
+        if (consultation.equals(editedConsultation) && model.hasConsultation(editedConsultation)) {
+            throw new CommandException(MESSAGE_DUPLICATE_CONSULTATION);
+        }
+
         model.setConsultation(consultation, editedConsultation);
 
         return new CommandResult(String.format(MESSAGE_EDIT_TEST_RESULT_SUCCESS, editedConsultation), COMMAND_TYPE);

--- a/src/main/java/seedu/address/logic/commands/consultation/EditConsultationCommand.java
+++ b/src/main/java/seedu/address/logic/commands/consultation/EditConsultationCommand.java
@@ -53,6 +53,8 @@ public class EditConsultationCommand extends Command {
     public static final String MESSAGE_EDIT_TEST_RESULT_SUCCESS = "Edited Consultation Information: \n%1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
     public static final String MESSAGE_DUPLICATE_CONSULTATION = "This consultation already exists in MedBook.";
+    public static final String MESSAGE_NRIC_EDIT_NOT_ALLOWED = "NRIC field cannot be modified. "
+            + "Create a new consultation instead.";
 
     private final Index targetIndex;
     private final EditConsultationDescriptor editConsultationDescriptor;

--- a/src/main/java/seedu/address/logic/commands/consultation/EditConsultationCommand.java
+++ b/src/main/java/seedu/address/logic/commands/consultation/EditConsultationCommand.java
@@ -12,10 +12,10 @@ import java.util.Optional;
 
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
+import seedu.address.commons.util.CollectionUtil;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.CommandType;
-import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.consultation.Consultation;
@@ -51,6 +51,8 @@ public class EditConsultationCommand extends Command {
             + PREFIX_TIME + "19-00 ";
 
     public static final String MESSAGE_EDIT_TEST_RESULT_SUCCESS = "Edited Consultation Information: \n%1$s";
+    public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
+    public static final String MESSAGE_DUPLICATE_CONTACT = "This contact already exists in MedBook.";
 
     private final Index targetIndex;
     private final EditConsultationDescriptor editConsultationDescriptor;
@@ -61,7 +63,7 @@ public class EditConsultationCommand extends Command {
      */
     public EditConsultationCommand(Index targetIndex, EditConsultationDescriptor editConsultationDescriptor) {
         this.targetIndex = targetIndex;
-        this.editConsultationDescriptor = editConsultationDescriptor;
+        this.editConsultationDescriptor = new EditConsultationDescriptor(editConsultationDescriptor);
     }
 
     @Override
@@ -135,6 +137,13 @@ public class EditConsultationCommand extends Command {
             setNotes(toCopy.notes);
         }
 
+        /**
+         * Returns true if at least one field is edited.
+         */
+        public boolean isAnyFieldEdited() {
+            return CollectionUtil.isAnyNonNull(date, time, diagnosis, fee, notes);
+        }
+
         public Optional<Date> getDate() {
             return Optional.ofNullable(date);
         }
@@ -183,7 +192,7 @@ public class EditConsultationCommand extends Command {
             }
 
             // instanceof handles nulls
-            if (!(other instanceof EditCommand.EditPatientDescriptor)) {
+            if (!(other instanceof EditConsultationDescriptor)) {
                 return false;
             }
 

--- a/src/main/java/seedu/address/logic/commands/consultation/EditConsultationCommand.java
+++ b/src/main/java/seedu/address/logic/commands/consultation/EditConsultationCommand.java
@@ -183,7 +183,7 @@ public class EditConsultationCommand extends Command {
             }
 
             // instanceof handles nulls
-            if (!(other instanceof EditCommand.EditPersonDescriptor)) {
+            if (!(other instanceof EditCommand.EditPatientDescriptor)) {
                 return false;
             }
 

--- a/src/main/java/seedu/address/logic/commands/contact/AddContactCommand.java
+++ b/src/main/java/seedu/address/logic/commands/contact/AddContactCommand.java
@@ -6,6 +6,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NRIC;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TYPE;
 
 import seedu.address.logic.commands.Command;
@@ -31,14 +32,17 @@ public class AddContactCommand extends Command {
             + PREFIX_NAME + "NAME "
             + PREFIX_PHONE + "PHONE "
             + PREFIX_EMAIL + "EMAIL "
-            + PREFIX_ADDRESS + "ADDRESS \n"
+            + PREFIX_ADDRESS + "ADDRESS"
+            + "[" + PREFIX_TAG + "TAG]...\n"
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_TYPE + "contact "
             + PREFIX_NRIC + "S1234567L "
             + PREFIX_NAME + "John Smith "
             + PREFIX_PHONE + "88888888 "
             + PREFIX_EMAIL + "johns@example.com "
-            + PREFIX_ADDRESS + "21 Lower Kent Ridge Road, Singapore 119077 ";
+            + PREFIX_ADDRESS + "21 Lower Kent Ridge Road, Singapore 119077 "
+            + PREFIX_TAG + "primary "
+            + PREFIX_TAG + "father";
 
     public static final String MESSAGE_SUCCESS = "New contact added: \n%1$s";
     public static final String MESSAGE_DUPLICATE_CONTACT = "This contact already exists in patient contact list";

--- a/src/main/java/seedu/address/logic/commands/contact/EditContactCommand.java
+++ b/src/main/java/seedu/address/logic/commands/contact/EditContactCommand.java
@@ -20,6 +20,7 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.CollectionUtil;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.CommandType;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
@@ -36,6 +37,7 @@ import seedu.address.model.tag.Tag;
  */
 public class EditContactCommand extends Command {
     public static final String COMMAND_WORD = "edit";
+    public static final CommandType COMMAND_TYPE = CommandType.CONTACT;
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the contact identified "
             + "by the index number used in the displayed contact list. "
@@ -53,7 +55,7 @@ public class EditContactCommand extends Command {
     public static final String MESSAGE_EDIT_CONTACT_SUCCESS = "Edited Contact: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
     public static final String MESSAGE_DUPLICATE_CONTACT = "This contact already exists in MedBook.";
-    public static final String MESSAGE_NRIC_EDIT_NOT_ALLOWED = "NRIC field cannot be modified."
+    public static final String MESSAGE_NRIC_EDIT_NOT_ALLOWED = "NRIC field cannot be modified. "
             + "Create a new contact instead.";
 
     private final Index index;
@@ -88,8 +90,8 @@ public class EditContactCommand extends Command {
         }
 
         model.setContact(contactToEdit, editedContact);
-        model.updateFilteredContactList(PREDICATE_SHOW_ALL_CONTACTS);
-        return new CommandResult(String.format(MESSAGE_EDIT_CONTACT_SUCCESS, editedContact));
+
+        return new CommandResult(String.format(MESSAGE_EDIT_CONTACT_SUCCESS, editedContact), COMMAND_TYPE);
     }
 
     /**

--- a/src/main/java/seedu/address/logic/commands/contact/EditContactCommand.java
+++ b/src/main/java/seedu/address/logic/commands/contact/EditContactCommand.java
@@ -6,8 +6,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_CONTACTS;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.Collections;
 import java.util.HashSet;
@@ -21,7 +19,6 @@ import seedu.address.commons.util.CollectionUtil;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.CommandType;
-import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.contact.Address;
@@ -42,6 +39,7 @@ public class EditContactCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the contact identified "
             + "by the index number used in the displayed contact list. "
             + "Existing values will be overwritten by the input values.\n"
+            + "NRIC FIELD CANNOT BE MODIFIED - CREATE A NEW CONTACT INSTEAD.\n"
             + "Parameters: INDEX (must be a positive integer) "
             + "[" + PREFIX_NAME + "NAME] "
             + "[" + PREFIX_PHONE + "PHONE] "

--- a/src/main/java/seedu/address/logic/commands/contact/EditContactCommand.java
+++ b/src/main/java/seedu/address/logic/commands/contact/EditContactCommand.java
@@ -1,0 +1,234 @@
+package seedu.address.logic.commands.contact;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_CONTACTS;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.commons.util.CollectionUtil;
+import seedu.address.logic.commands.Command;
+import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.EditCommand;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.contact.Address;
+import seedu.address.model.contact.Contact;
+import seedu.address.model.contact.Email;
+import seedu.address.model.contact.Phone;
+import seedu.address.model.patient.Name;
+import seedu.address.model.patient.Nric;
+import seedu.address.model.tag.Tag;
+
+/**
+ * Edits the details of an existing contact in MedBook
+ */
+public class EditContactCommand extends Command {
+    public static final String COMMAND_WORD = "edit";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the contact identified "
+            + "by the index number used in the displayed contact list. "
+            + "Existing values will be overwritten by the input values.\n"
+            + "Parameters: INDEX (must be a positive integer) "
+            + "[" + PREFIX_NAME + "NAME] "
+            + "[" + PREFIX_PHONE + "PHONE] "
+            + "[" + PREFIX_EMAIL + "EMAIL] "
+            + "[" + PREFIX_ADDRESS + "ADDRESS] "
+            + "[" + PREFIX_TAG + "TAG]...\n"
+            + "Example: " + COMMAND_WORD + " 1 "
+            + PREFIX_PHONE + "91234567 "
+            + PREFIX_EMAIL + "johndoe@example.com";
+
+    public static final String MESSAGE_EDIT_CONTACT_SUCCESS = "Edited Contact: %1$s";
+    public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
+    public static final String MESSAGE_DUPLICATE_CONTACT = "This contact already exists in MedBook.";
+    public static final String MESSAGE_NRIC_EDIT_NOT_ALLOWED = "NRIC field cannot be modified."
+            + "Create a new contact instead.";
+
+    private final Index index;
+    private final EditContactDescriptor editContactDescriptor;
+
+    /**
+     * @param index of the contact in the filtered contact list to edit
+     * @param editContactDescriptor details to edit the contact with
+     */
+    public EditContactCommand(Index index, EditContactDescriptor editContactDescriptor) {
+        requireNonNull(index);
+        requireNonNull(editContactDescriptor);
+
+        this.index = index;
+        this.editContactDescriptor = new EditContactDescriptor(editContactDescriptor);
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Contact> lastShownList = model.getFilteredContactList();
+
+        if (index.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_PATIENT_DISPLAYED_INDEX);
+        }
+
+        Contact contactToEdit = lastShownList.get(index.getZeroBased());
+        Contact editedContact = createEditedContact(contactToEdit, editContactDescriptor);
+
+        if (!contactToEdit.isSameContact(editedContact) && model.hasContact(editedContact)) {
+            throw new CommandException(MESSAGE_DUPLICATE_CONTACT);
+        }
+
+        model.setContact(contactToEdit, editedContact);
+        model.updateFilteredContactList(PREDICATE_SHOW_ALL_CONTACTS);
+        return new CommandResult(String.format(MESSAGE_EDIT_CONTACT_SUCCESS, editedContact));
+    }
+
+    /**
+     * Creates and returns a {@code Contact} with the details of {@code contactToEdit}
+     * edited with {@code editContactDescriptor}.
+     */
+    private static Contact createEditedContact(Contact contactToEdit, EditContactDescriptor editContactDescriptor) {
+        assert contactToEdit != null;
+
+        Nric ownerNric = contactToEdit.getOwnerNric();
+        Name updatedName = editContactDescriptor.getName().orElse(contactToEdit.getName());
+        Phone updatedPhone = editContactDescriptor.getPhone().orElse(contactToEdit.getPhone());
+        Email updatedEmail = editContactDescriptor.getEmail().orElse(contactToEdit.getEmail());
+        Address updatedAddress = editContactDescriptor.getAddress().orElse(contactToEdit.getAddress());
+        Set<Tag> updatedTags = editContactDescriptor.getTags().orElse(contactToEdit.getTags());
+
+        return new Contact(ownerNric, updatedName, updatedPhone, updatedEmail, updatedAddress, updatedTags);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        // short circuit if same object
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof EditContactCommand)) {
+            return false;
+        }
+
+        // state check
+        EditContactCommand e = (EditContactCommand) other;
+        return index.equals(e.index)
+                && editContactDescriptor.equals(e.editContactDescriptor);
+    }
+
+    /**
+     * Stores the details to edit the contact with. Each non-empty field value will replace the
+     * corresponding field value of the contact.
+     */
+    public static class EditContactDescriptor {
+        private Name name;
+        private Phone phone;
+        private Email email;
+        private Address address;
+        private Set<Tag> tags;
+
+        public EditContactDescriptor() {}
+
+        /**
+         * Copy constructor.
+         * A defensive copy of {@code tags} is used internally.
+         */
+        public EditContactDescriptor(EditContactDescriptor toCopy) {
+            setName(toCopy.name);
+            setPhone(toCopy.phone);
+            setEmail(toCopy.email);
+            setAddress(toCopy.address);
+            setTags(toCopy.tags);
+        }
+
+        /**
+         * Returns true if at least one field is edited.
+         */
+        public boolean isAnyFieldEdited() {
+            return CollectionUtil.isAnyNonNull(name, phone, email, address, tags);
+        }
+
+        public void setName(Name name) {
+            this.name = name;
+        }
+
+        public Optional<Name> getName() {
+            return Optional.ofNullable(name);
+        }
+
+        public void setPhone(Phone phone) {
+            this.phone = phone;
+        }
+
+        public Optional<Phone> getPhone() {
+            return Optional.ofNullable(phone);
+        }
+
+        public void setEmail(Email email) {
+            this.email = email;
+        }
+
+        public Optional<Email> getEmail() {
+            return Optional.ofNullable(email);
+        }
+
+        public void setAddress(Address address) {
+            this.address = address;
+        }
+
+        public Optional<Address> getAddress() {
+            return Optional.ofNullable(address);
+        }
+
+        /**
+         * Sets {@code tags} to this object's {@code tags}.
+         * A defensive copy of {@code tags} is used internally.
+         */
+        public void setTags(Set<Tag> tags) {
+            this.tags = (tags != null) ? new HashSet<>(tags) : null;
+        }
+
+        /**
+         * Returns an unmodifiable tag set, which throws {@code UnsupportedOperationException}
+         * if modification is attempted.
+         * Returns {@code Optional#empty()} if {@code tags} is null.
+         */
+        public Optional<Set<Tag>> getTags() {
+            return (tags != null) ? Optional.of(Collections.unmodifiableSet(tags)) : Optional.empty();
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            // short circuit if same object
+            if (other == this) {
+                return true;
+            }
+
+            // instanceof handles nulls
+            if (!(other instanceof EditContactDescriptor)) {
+                return false;
+            }
+
+            // state check
+            EditContactDescriptor e = (EditContactDescriptor) other;
+
+            return getName().equals(e.getName())
+                    && getPhone().equals(e.getPhone())
+                    && getEmail().equals(e.getEmail())
+                    && getAddress().equals(e.getAddress())
+                    && getTags().equals(e.getTags());
+        }
+    }
+
+}

--- a/src/main/java/seedu/address/logic/commands/medical/EditMedicalCommand.java
+++ b/src/main/java/seedu/address/logic/commands/medical/EditMedicalCommand.java
@@ -10,7 +10,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_HEIGHT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ILLNESSES;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_IMMUNIZATION_HISTORY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_MEDICATION;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NRIC;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SURGERIES;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_WEIGHT;
 
@@ -52,7 +51,6 @@ public class EditMedicalCommand extends Command {
             + "Existing values will be overwritten by the input values.\n"
             + "NRIC FIELD CANNOT BE MODIFIED - CREATE A NEW MEDICAL INFORMATION INSTEAD.\n"
             + "Parameters: INDEX (must be a positive integer) "
-            + PREFIX_NRIC + "NRIC "
             + PREFIX_AGE + "AGE "
             + PREFIX_BLOODTYPE + "BLOODTYPE "
             + PREFIX_MEDICATION + "MEDICATION "
@@ -65,10 +63,11 @@ public class EditMedicalCommand extends Command {
             + PREFIX_GENDER + "GENDER "
             + PREFIX_ETHNICITY + "ETHNICITY\n"
             + "Example: " + COMMAND_WORD + " 1 "
-            + PREFIX_NRIC + "S1234567L "
             + PREFIX_BLOODTYPE + "B";
 
     public static final String MESSAGE_EDIT_MEDICAL_SUCCESS = "Edited Medical Information: %1$s";
+    public static final String MESSAGE_NRIC_EDIT_NOT_ALLOWED = "NRIC field cannot be modified. "
+            + "Create a new medical information instead.";
 
     private final Index targetIndex;
     private final EditMedicalDescriptor editMedicalDescriptor;
@@ -102,7 +101,7 @@ public class EditMedicalCommand extends Command {
                                                EditMedicalCommand.EditMedicalDescriptor editMedicalDescriptor) {
         assert medicalToEdit != null;
 
-        Nric updatedNric = editMedicalDescriptor.getNric().orElse(medicalToEdit.getPatientNric());
+        Nric updatedNric = medicalToEdit.getPatientNric();
         Age updatedAge = editMedicalDescriptor.getAge().orElse(medicalToEdit.getAge());
         BloodType updatedBloodType =
                 editMedicalDescriptor.getBloodType().orElse(medicalToEdit.getBloodType());
@@ -152,7 +151,6 @@ public class EditMedicalCommand extends Command {
      * corresponding field value of the medical information.
      */
     public static class EditMedicalDescriptor {
-        private Nric nric;
         private Age age;
         private BloodType bloodType;
         private Medication medication;
@@ -172,7 +170,6 @@ public class EditMedicalCommand extends Command {
          * A defensive copy of {@code tags} is used internally.
          */
         public EditMedicalDescriptor(EditMedicalCommand.EditMedicalDescriptor toCopy) {
-            setNric(toCopy.nric);
             setAge(toCopy.age);
             setBloodType(toCopy.bloodType);
             setMedication(toCopy.medication);
@@ -184,14 +181,6 @@ public class EditMedicalCommand extends Command {
             setImmunizationHistory(toCopy.immunizationHistory);
             setGender(toCopy.gender);
             setEthnicity(toCopy.ethnicity);
-        }
-
-        public Optional<Nric> getNric() {
-            return Optional.ofNullable(nric);
-        }
-
-        public void setNric(Nric nric) {
-            this.nric = nric;
         }
 
         public Optional<Age> getAge() {
@@ -297,8 +286,7 @@ public class EditMedicalCommand extends Command {
             // state check
             EditMedicalCommand.EditMedicalDescriptor e = (EditMedicalCommand.EditMedicalDescriptor) other;
 
-            return getNric().equals(e.getNric())
-                    && getAge().equals(e.getAge())
+            return getAge().equals(e.getAge())
                     && getBloodType().equals(e.getBloodType())
                     && getMedication().equals(e.getMedication())
                     && getHeight().equals(e.getHeight())

--- a/src/main/java/seedu/address/logic/commands/medical/EditMedicalCommand.java
+++ b/src/main/java/seedu/address/logic/commands/medical/EditMedicalCommand.java
@@ -290,7 +290,7 @@ public class EditMedicalCommand extends Command {
             }
 
             // instanceof handles nulls
-            if (!(other instanceof EditCommand.EditPersonDescriptor)) {
+            if (!(other instanceof EditCommand.EditPatientDescriptor)) {
                 return false;
             }
 

--- a/src/main/java/seedu/address/logic/commands/prescription/EditPrescriptionCommand.java
+++ b/src/main/java/seedu/address/logic/commands/prescription/EditPrescriptionCommand.java
@@ -4,13 +4,13 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_INSTRUCTION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NRIC;
 
 import java.util.List;
 import java.util.Optional;
 
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
+import seedu.address.commons.util.CollectionUtil;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.CommandType;
@@ -41,6 +41,10 @@ public class EditPrescriptionCommand extends Command {
             + PREFIX_INSTRUCTION + "1 tablet per day";
 
     public static final String MESSAGE_EDIT_PRESCRIPTION_SUCCESS = "Edited Prescription Information: %1$s";
+    public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
+    public static final String MESSAGE_DUPLICATE_PRESCRIPTION = "This prescription already exists in MedBook.";
+    public static final String MESSAGE_NRIC_EDIT_NOT_ALLOWED = "NRIC field cannot be modified. "
+            + "Create a new prescription instead.";
 
     private final Index targetIndex;
     private final EditPrescriptionCommand.EditPrescriptionDescriptor editPrescriptionDescriptor;
@@ -50,9 +54,9 @@ public class EditPrescriptionCommand extends Command {
      * @param editPrescriptionDescriptor details to edit the test result information with
      */
     public EditPrescriptionCommand(Index targetIndex,
-                                   EditPrescriptionCommand.EditPrescriptionDescriptor editPrescriptionDescriptor) {
+                                   EditPrescriptionDescriptor editPrescriptionDescriptor) {
         this.targetIndex = targetIndex;
-        this.editPrescriptionDescriptor = editPrescriptionDescriptor;
+        this.editPrescriptionDescriptor = new EditPrescriptionDescriptor(editPrescriptionDescriptor);
     }
 
     @Override
@@ -64,9 +68,14 @@ public class EditPrescriptionCommand extends Command {
             throw new CommandException(Messages.MESSAGE_INVALID_PRESCRIPTION_DISPLAYED_INDEX);
         }
 
-        Prescription prescription = lastShownList.get(targetIndex.getZeroBased());
-        Prescription editedPrescription = createEditedPrescription(prescription, editPrescriptionDescriptor);
-        model.setPrescription(prescription, editedPrescription);
+        Prescription prescriptionToEdit = lastShownList.get(targetIndex.getZeroBased());
+        Prescription editedPrescription = createEditedPrescription(prescriptionToEdit, editPrescriptionDescriptor);
+
+        if (!prescriptionToEdit.equals(editedPrescription) && model.hasPrescription(editedPrescription)) {
+            throw new CommandException(MESSAGE_DUPLICATE_PRESCRIPTION);
+        }
+
+        model.setPrescription(prescriptionToEdit, editedPrescription);
 
         return new CommandResult(String.format(MESSAGE_EDIT_PRESCRIPTION_SUCCESS, editedPrescription), COMMAND_TYPE);
     }
@@ -76,7 +85,7 @@ public class EditPrescriptionCommand extends Command {
                                                              editPrescriptionDescriptor) {
         assert prescription != null;
 
-        Nric updatedNric = editPrescriptionDescriptor.getNric().orElse(prescription.getPrescriptionTarget());
+        Nric updatedNric = prescription.getPrescriptionTarget();
         DrugName updatedDrugName = editPrescriptionDescriptor.getDrugName().orElse(prescription.getDrugName());
         PrescriptionDate updatedPrescriptionDate =
                 editPrescriptionDescriptor.getPrescriptionDate().orElse(prescription.getPrescriptionDate());
@@ -102,7 +111,6 @@ public class EditPrescriptionCommand extends Command {
      * corresponding field value of the test result information.
      */
     public static class EditPrescriptionDescriptor {
-        private Nric nric;
         private DrugName drugName;
         private PrescriptionDate date;
         private Instruction instruction;
@@ -114,18 +122,13 @@ public class EditPrescriptionCommand extends Command {
          * A defensive copy of {@code tags} is used internally.
          */
         public EditPrescriptionDescriptor(EditPrescriptionCommand.EditPrescriptionDescriptor toCopy) {
-            setNric(toCopy.nric);
             setDrugName(toCopy.drugName);
             setPrescriptionDate(toCopy.date);
             setResult(toCopy.instruction);
         }
 
-        public Optional<Nric> getNric() {
-            return Optional.ofNullable(nric);
-        }
-
-        public void setNric(Nric nric) {
-            this.nric = nric;
+        public boolean isAnyFieldEdited() {
+            return CollectionUtil.isAnyNonNull(drugName, date, instruction);
         }
 
         public Optional<DrugName> getDrugName() {
@@ -168,8 +171,7 @@ public class EditPrescriptionCommand extends Command {
             EditPrescriptionCommand.EditPrescriptionDescriptor e =
                     (EditPrescriptionCommand.EditPrescriptionDescriptor) other;
 
-            return getNric().equals(e.getNric())
-                    && getDrugName().equals(e.getDrugName())
+            return getDrugName().equals(e.getDrugName())
                     && getPrescriptionDate().equals(e.getPrescriptionDate())
                     && getInstruction().equals(e.getInstruction());
         }

--- a/src/main/java/seedu/address/logic/commands/prescription/EditPrescriptionCommand.java
+++ b/src/main/java/seedu/address/logic/commands/prescription/EditPrescriptionCommand.java
@@ -34,12 +34,10 @@ public class EditPrescriptionCommand extends Command {
             + "Existing values will be overwritten by the input values.\n"
             + "NRIC FIELD CANNOT BE MODIFIED - CREATE A NEW PRESCRIPTION INSTEAD.\n"
             + "Parameters: INDEX (must be a positive integer) "
-            + PREFIX_NRIC + "PATIENT_NRIC "
             + PREFIX_NAME + "DRUG_NAME "
             + PREFIX_DATE + "DATE "
             + PREFIX_INSTRUCTION + "INSTRUCTION \n"
             + "Example: " + COMMAND_WORD + " 1 "
-            + PREFIX_NRIC + "S1234567L "
             + PREFIX_INSTRUCTION + "1 tablet per day";
 
     public static final String MESSAGE_EDIT_PRESCRIPTION_SUCCESS = "Edited Prescription Information: %1$s";
@@ -63,7 +61,7 @@ public class EditPrescriptionCommand extends Command {
         List<Prescription> lastShownList = model.getFilteredPrescriptionList();
 
         if (targetIndex.getZeroBased() >= lastShownList.size()) {
-            throw new CommandException(Messages.MESSAGE_INVALID_TEST_RESULT_INDEX);
+            throw new CommandException(Messages.MESSAGE_INVALID_PRESCRIPTION_DISPLAYED_INDEX);
         }
 
         Prescription prescription = lastShownList.get(targetIndex.getZeroBased());

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -11,7 +11,7 @@ public class CliSyntax {
     public static final Prefix PREFIX_PHONE = new Prefix("p/");
     public static final Prefix PREFIX_EMAIL = new Prefix("e/");
     public static final Prefix PREFIX_ADDRESS = new Prefix("a/");
-    public static final Prefix PREFIX_TAG = new Prefix("l/");
+    public static final Prefix PREFIX_TAG = new Prefix("tg/");
 
     /* Consultation Prefixes */
     public static final Prefix PREFIX_DATE = new Prefix("dt/");

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -16,7 +16,7 @@ import java.util.Set;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.EditCommand;
-import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
+import seedu.address.logic.commands.EditCommand.EditPatientDescriptor;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.tag.Tag;
 
@@ -44,29 +44,29 @@ public class EditCommandParser implements Parser<EditCommand> {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE), pe);
         }
 
-        EditPersonDescriptor editPersonDescriptor = new EditPersonDescriptor();
+        EditPatientDescriptor editPatientDescriptor = new EditPatientDescriptor();
         if (argMultimap.getValue(PREFIX_NRIC).isPresent()) {
-            editPersonDescriptor.setNric(ParserUtil.parseNric(argMultimap.getValue(PREFIX_NRIC).get()));
+            editPatientDescriptor.setNric(ParserUtil.parseNric(argMultimap.getValue(PREFIX_NRIC).get()));
         }
         if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
-            editPersonDescriptor.setName(ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get()));
+            editPatientDescriptor.setName(ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get()));
         }
         if (argMultimap.getValue(PREFIX_PHONE).isPresent()) {
-            editPersonDescriptor.setPhone(ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get()));
+            editPatientDescriptor.setPhone(ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get()));
         }
         if (argMultimap.getValue(PREFIX_EMAIL).isPresent()) {
-            editPersonDescriptor.setEmail(ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get()));
+            editPatientDescriptor.setEmail(ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get()));
         }
         if (argMultimap.getValue(PREFIX_ADDRESS).isPresent()) {
-            editPersonDescriptor.setAddress(ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get()));
+            editPatientDescriptor.setAddress(ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get()));
         }
-        parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(editPersonDescriptor::setTags);
+        parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(editPatientDescriptor::setTags);
 
-        if (!editPersonDescriptor.isAnyFieldEdited()) {
+        if (!editPatientDescriptor.isAnyFieldEdited()) {
             throw new ParseException(EditCommand.MESSAGE_NOT_EDITED);
         }
 
-        return new EditCommand(index, editPersonDescriptor);
+        return new EditCommand(index, editPatientDescriptor);
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -36,6 +36,10 @@ public class EditCommandParser implements Parser<EditCommand> {
                 ArgumentTokenizer.tokenize(args, PREFIX_NRIC, PREFIX_NAME, PREFIX_PHONE,
                         PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_TAG);
 
+        if (argMultimap.getValue(PREFIX_NRIC).isPresent()) {
+            throw new ParseException(EditCommand.MESSAGE_NRIC_EDIT_NOT_ALLOWED);
+        }
+
         Index index;
 
         try {
@@ -45,9 +49,6 @@ public class EditCommandParser implements Parser<EditCommand> {
         }
 
         EditPatientDescriptor editPatientDescriptor = new EditPatientDescriptor();
-        if (argMultimap.getValue(PREFIX_NRIC).isPresent()) {
-            editPatientDescriptor.setNric(ParserUtil.parseNric(argMultimap.getValue(PREFIX_NRIC).get()));
-        }
         if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
             editPatientDescriptor.setName(ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get()));
         }

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -36,16 +36,17 @@ public class EditCommandParser implements Parser<EditCommand> {
                 ArgumentTokenizer.tokenize(args, PREFIX_NRIC, PREFIX_NAME, PREFIX_PHONE,
                         PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_TAG);
 
-        if (argMultimap.getValue(PREFIX_NRIC).isPresent()) {
-            throw new ParseException(EditCommand.MESSAGE_NRIC_EDIT_NOT_ALLOWED);
-        }
-
         Index index;
 
         try {
             index = ParserUtil.parseIndex(argMultimap.getPreamble());
         } catch (ParseException pe) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE), pe);
+        }
+
+
+        if (argMultimap.getValue(PREFIX_NRIC).isPresent()) {
+            throw new ParseException(EditCommand.MESSAGE_NRIC_EDIT_NOT_ALLOWED);
         }
 
         EditPatientDescriptor editPatientDescriptor = new EditPatientDescriptor();

--- a/src/main/java/seedu/address/logic/parser/consultations/EditConsultationCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/consultations/EditConsultationCommandParser.java
@@ -6,6 +6,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DIAGNOSIS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_FEE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTES;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NRIC;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TIME;
 
 import seedu.address.commons.core.index.Index;
@@ -28,7 +29,7 @@ public class EditConsultationCommandParser implements Parser<EditConsultationCom
      */
     public EditConsultationCommand parse(String args) throws ParseException {
         requireNonNull(args);
-        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_DATE,
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NRIC, PREFIX_DATE,
                 PREFIX_TIME, PREFIX_DIAGNOSIS, PREFIX_FEE, PREFIX_NOTES);
 
         Index index;
@@ -38,6 +39,10 @@ public class EditConsultationCommandParser implements Parser<EditConsultationCom
         } catch (ParseException pe) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                     EditConsultationCommand.MESSAGE_USAGE), pe);
+        }
+
+        if (argMultimap.getValue(PREFIX_NRIC).isPresent()) {
+            throw new ParseException(EditConsultationCommand.MESSAGE_NRIC_EDIT_NOT_ALLOWED);
         }
 
         EditConsultationDescriptor editConsultationDescriptor =

--- a/src/main/java/seedu/address/logic/parser/consultations/EditConsultationCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/consultations/EditConsultationCommandParser.java
@@ -10,15 +10,17 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_TIME;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.consultation.EditConsultationCommand;
+import seedu.address.logic.commands.consultation.EditConsultationCommand.EditConsultationDescriptor;
 import seedu.address.logic.parser.ArgumentMultimap;
 import seedu.address.logic.parser.ArgumentTokenizer;
+import seedu.address.logic.parser.Parser;
 import seedu.address.logic.parser.ParserUtil;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
  * Parses input arguments and creates a new EditConsultationCommand object
  */
-public class EditConsultationCommandParser {
+public class EditConsultationCommandParser implements Parser<EditConsultationCommand> {
     /**
      * Parses the given {@code String} of arguments in the context of the EditConsultationCommand
      * and returns an EditConsultationCommand object for execution.
@@ -26,40 +28,46 @@ public class EditConsultationCommandParser {
      */
     public EditConsultationCommand parse(String args) throws ParseException {
         requireNonNull(args);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_DATE,
+                PREFIX_TIME, PREFIX_DIAGNOSIS, PREFIX_FEE, PREFIX_NOTES);
+
+        Index index;
+
         try {
-            ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_DATE,
-                    PREFIX_TIME, PREFIX_DIAGNOSIS, PREFIX_FEE, PREFIX_NOTES);
-
-            Index index = ParserUtil.parseIndex(argMultimap.getPreamble());
-
-            EditConsultationCommand.EditConsultationDescriptor editConsultationDescriptor =
-                    new EditConsultationCommand.EditConsultationDescriptor();
-
-            if (argMultimap.getValue(PREFIX_DATE).isPresent()) {
-                editConsultationDescriptor.setDate(ParserUtil.parseDate(
-                        argMultimap.getValue(PREFIX_DATE).get()));
-            }
-            if (argMultimap.getValue(PREFIX_TIME).isPresent()) {
-                editConsultationDescriptor.setTime(ParserUtil.parseTime(
-                        argMultimap.getValue(PREFIX_TIME).get()));
-            }
-            if (argMultimap.getValue(PREFIX_DIAGNOSIS).isPresent()) {
-                editConsultationDescriptor.setDiagnosis(ParserUtil.parseDiagnosis(
-                        argMultimap.getValue(PREFIX_DIAGNOSIS).get()));
-            }
-            if (argMultimap.getValue(PREFIX_FEE).isPresent()) {
-                editConsultationDescriptor.setFee(ParserUtil.parseFee(
-                        argMultimap.getValue(PREFIX_FEE).get()));
-            }
-            if (argMultimap.getValue(PREFIX_NOTES).isPresent()) {
-                editConsultationDescriptor.setNotes(ParserUtil.parseNotes(
-                        argMultimap.getValue(PREFIX_NOTES).get()));
-            }
-
-            return new EditConsultationCommand(index, editConsultationDescriptor);
+            index = ParserUtil.parseIndex(argMultimap.getPreamble());
         } catch (ParseException pe) {
-            throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditConsultationCommand.MESSAGE_USAGE), pe);
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    EditConsultationCommand.MESSAGE_USAGE), pe);
         }
+
+        EditConsultationDescriptor editConsultationDescriptor =
+                new EditConsultationDescriptor();
+
+        if (argMultimap.getValue(PREFIX_DATE).isPresent()) {
+            editConsultationDescriptor.setDate(ParserUtil.parseDate(
+                    argMultimap.getValue(PREFIX_DATE).get()));
+        }
+        if (argMultimap.getValue(PREFIX_TIME).isPresent()) {
+            editConsultationDescriptor.setTime(ParserUtil.parseTime(
+                    argMultimap.getValue(PREFIX_TIME).get()));
+        }
+        if (argMultimap.getValue(PREFIX_DIAGNOSIS).isPresent()) {
+            editConsultationDescriptor.setDiagnosis(ParserUtil.parseDiagnosis(
+                    argMultimap.getValue(PREFIX_DIAGNOSIS).get()));
+        }
+        if (argMultimap.getValue(PREFIX_FEE).isPresent()) {
+            editConsultationDescriptor.setFee(ParserUtil.parseFee(
+                    argMultimap.getValue(PREFIX_FEE).get()));
+        }
+        if (argMultimap.getValue(PREFIX_NOTES).isPresent()) {
+            editConsultationDescriptor.setNotes(ParserUtil.parseNotes(
+                    argMultimap.getValue(PREFIX_NOTES).get()));
+        }
+
+        if (!editConsultationDescriptor.isAnyFieldEdited()) {
+            throw new ParseException(EditConsultationCommand.MESSAGE_NOT_EDITED);
+        }
+
+        return new EditConsultationCommand(index, editConsultationDescriptor);
     }
 }

--- a/src/main/java/seedu/address/logic/parser/contact/EditContactCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/contact/EditContactCommandParser.java
@@ -1,0 +1,89 @@
+package seedu.address.logic.parser.contact;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NRIC;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.Set;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.contact.EditContactCommand;
+import seedu.address.logic.commands.contact.EditContactCommand.EditContactDescriptor;
+import seedu.address.logic.parser.ArgumentMultimap;
+import seedu.address.logic.parser.ArgumentTokenizer;
+import seedu.address.logic.parser.Parser;
+import seedu.address.logic.parser.ParserUtil;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.tag.Tag;
+
+public class EditContactCommandParser implements Parser<EditContactCommand> {
+    /**
+     * Parses the given {@code String} of arguments in the context of the EditContactCommand
+     * and returns an EditContactCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public EditContactCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_NRIC, PREFIX_NAME, PREFIX_PHONE,
+                        PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_TAG);
+
+        if (argMultimap.getValue(PREFIX_NRIC).isPresent()) {
+            throw new ParseException(EditContactCommand.MESSAGE_NRIC_EDIT_NOT_ALLOWED);
+        }
+
+        Index index;
+
+        try {
+            index = ParserUtil.parseIndex(argMultimap.getPreamble());
+        } catch (ParseException pe) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    EditContactCommand.MESSAGE_USAGE), pe);
+        }
+
+        EditContactDescriptor editContactDescriptor = new EditContactDescriptor();
+
+        if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
+            editContactDescriptor.setName(ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get()));
+        }
+        if (argMultimap.getValue(PREFIX_PHONE).isPresent()) {
+            editContactDescriptor.setPhone(ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get()));
+        }
+        if (argMultimap.getValue(PREFIX_EMAIL).isPresent()) {
+            editContactDescriptor.setEmail(ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get()));
+        }
+        if (argMultimap.getValue(PREFIX_ADDRESS).isPresent()) {
+            editContactDescriptor.setAddress(ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get()));
+        }
+        parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(editContactDescriptor::setTags);
+
+        if (!editContactDescriptor.isAnyFieldEdited()) {
+            throw new ParseException(EditContactCommand.MESSAGE_NOT_EDITED);
+        }
+
+        return new EditContactCommand(index, editContactDescriptor);
+    }
+
+    /**
+     * Parses {@code Collection<String> tags} into a {@code Set<Tag>} if {@code tags} is non-empty.
+     * If {@code tags} contain only one element which is an empty string, it will be parsed into a
+     * {@code Set<Tag>} containing zero tags.
+     */
+    private Optional<Set<Tag>> parseTagsForEdit(Collection<String> tags) throws ParseException {
+        assert tags != null;
+
+        if (tags.isEmpty()) {
+            return Optional.empty();
+        }
+        Collection<String> tagSet = tags.size() == 1 && tags.contains("") ? Collections.emptySet() : tags;
+        return Optional.of(ParserUtil.parseTags(tagSet));
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/contact/EditContactCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/contact/EditContactCommandParser.java
@@ -36,10 +36,6 @@ public class EditContactCommandParser implements Parser<EditContactCommand> {
                 ArgumentTokenizer.tokenize(args, PREFIX_NRIC, PREFIX_NAME, PREFIX_PHONE,
                         PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_TAG);
 
-        if (argMultimap.getValue(PREFIX_NRIC).isPresent()) {
-            throw new ParseException(EditContactCommand.MESSAGE_NRIC_EDIT_NOT_ALLOWED);
-        }
-
         Index index;
 
         try {
@@ -47,6 +43,10 @@ public class EditContactCommandParser implements Parser<EditContactCommand> {
         } catch (ParseException pe) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                     EditContactCommand.MESSAGE_USAGE), pe);
+        }
+
+        if (argMultimap.getValue(PREFIX_NRIC).isPresent()) {
+            throw new ParseException(EditContactCommand.MESSAGE_NRIC_EDIT_NOT_ALLOWED);
         }
 
         EditContactDescriptor editContactDescriptor = new EditContactDescriptor();

--- a/src/main/java/seedu/address/logic/parser/medical/EditMedicalCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/medical/EditMedicalCommandParser.java
@@ -19,6 +19,7 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.medical.EditMedicalCommand;
 import seedu.address.logic.parser.ArgumentMultimap;
 import seedu.address.logic.parser.ArgumentTokenizer;
+import seedu.address.logic.parser.Parser;
 import seedu.address.logic.parser.ParserUtil;
 import seedu.address.logic.parser.exceptions.ParseException;
 
@@ -26,7 +27,7 @@ import seedu.address.logic.parser.exceptions.ParseException;
 /**
  * Parses input arguments and creates a new EditMedicalCommand object
  */
-public class EditMedicalCommandParser {
+public class EditMedicalCommandParser implements Parser<EditMedicalCommand> {
     /**
      * Parses the given {@code String} of arguments in the context of the EditMedicalCommand
      * and returns an EditMedicalCommand object for execution.
@@ -51,12 +52,13 @@ public class EditMedicalCommandParser {
 
             Index index = ParserUtil.parseIndex(argMultimap.getPreamble());
 
+            if (argMultimap.getValue(PREFIX_NRIC).isPresent()) {
+                throw new ParseException(EditMedicalCommand.MESSAGE_NRIC_EDIT_NOT_ALLOWED);
+            }
+
             EditMedicalCommand.EditMedicalDescriptor editMedicalDescriptor =
                     new EditMedicalCommand.EditMedicalDescriptor();
 
-            if (argMultimap.getValue(PREFIX_NRIC).isPresent()) {
-                editMedicalDescriptor.setNric(ParserUtil.parseNric(argMultimap.getValue(PREFIX_NRIC).get()));
-            }
             if (argMultimap.getValue(PREFIX_AGE).isPresent()) {
                 editMedicalDescriptor.setAge(ParserUtil.parseAge(argMultimap.getValue(PREFIX_AGE).get()));
             }

--- a/src/main/java/seedu/address/logic/parser/prescription/EditPrescriptionCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/prescription/EditPrescriptionCommandParser.java
@@ -26,35 +26,41 @@ public class EditPrescriptionCommandParser {
      */
     public EditPrescriptionCommand parse(String args) throws ParseException {
         requireNonNull(args);
-        try {
-            ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NRIC, PREFIX_NAME, PREFIX_DATE,
-                    PREFIX_INSTRUCTION);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NRIC, PREFIX_NAME, PREFIX_DATE,
+                PREFIX_INSTRUCTION);
 
-            Index index = ParserUtil.parseIndex(argMultimap.getPreamble());
-
-            EditPrescriptionCommand.EditPrescriptionDescriptor editPrescriptionDescriptor =
-                    new EditPrescriptionCommand.EditPrescriptionDescriptor();
-
-            if (argMultimap.getValue(PREFIX_NRIC).isPresent()) {
-                editPrescriptionDescriptor.setNric(ParserUtil.parseNric(argMultimap.getValue(PREFIX_NRIC).get()));
-            }
-            if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
-                editPrescriptionDescriptor.setDrugName(ParserUtil.parseDrugName(
-                        argMultimap.getValue(PREFIX_NAME).get()));
-            }
-            if (argMultimap.getValue(PREFIX_DATE).isPresent()) {
-                editPrescriptionDescriptor.setPrescriptionDate(ParserUtil.parsePrescriptionDate(
-                        argMultimap.getValue(PREFIX_DATE).get()));
-            }
-            if (argMultimap.getValue(PREFIX_INSTRUCTION).isPresent()) {
-                editPrescriptionDescriptor
-                        .setResult(ParserUtil.parseInstruction(argMultimap.getValue(PREFIX_INSTRUCTION).get()));
-            }
-
-            return new EditPrescriptionCommand(index, editPrescriptionDescriptor);
-        } catch (ParseException pe) {
-            throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditPrescriptionCommand.MESSAGE_USAGE), pe);
+        if (argMultimap.getValue(PREFIX_NRIC).isPresent()) {
+            throw new ParseException(EditPrescriptionCommand.MESSAGE_NRIC_EDIT_NOT_ALLOWED);
         }
+
+        Index index;
+
+        try {
+            index = ParserUtil.parseIndex(argMultimap.getPreamble());
+        } catch (ParseException pe) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    EditPrescriptionCommand.MESSAGE_USAGE), pe);
+        }
+
+        EditPrescriptionCommand.EditPrescriptionDescriptor editPrescriptionDescriptor =
+                new EditPrescriptionCommand.EditPrescriptionDescriptor();
+        if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
+            editPrescriptionDescriptor.setDrugName(ParserUtil.parseDrugName(
+                    argMultimap.getValue(PREFIX_NAME).get()));
+        }
+        if (argMultimap.getValue(PREFIX_DATE).isPresent()) {
+            editPrescriptionDescriptor.setPrescriptionDate(ParserUtil.parsePrescriptionDate(
+                    argMultimap.getValue(PREFIX_DATE).get()));
+        }
+        if (argMultimap.getValue(PREFIX_INSTRUCTION).isPresent()) {
+            editPrescriptionDescriptor
+                    .setResult(ParserUtil.parseInstruction(argMultimap.getValue(PREFIX_INSTRUCTION).get()));
+        }
+
+        if (!editPrescriptionDescriptor.isAnyFieldEdited()) {
+            throw new ParseException(EditPrescriptionCommand.MESSAGE_NOT_EDITED);
+        }
+
+        return new EditPrescriptionCommand(index, editPrescriptionDescriptor);
     }
 }

--- a/src/main/java/seedu/address/logic/parser/prescription/EditPrescriptionCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/prescription/EditPrescriptionCommandParser.java
@@ -11,13 +11,14 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.prescription.EditPrescriptionCommand;
 import seedu.address.logic.parser.ArgumentMultimap;
 import seedu.address.logic.parser.ArgumentTokenizer;
+import seedu.address.logic.parser.Parser;
 import seedu.address.logic.parser.ParserUtil;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
  * Parses input arguments and creates a new EditPrescriptionCommand object
  */
-public class EditPrescriptionCommandParser {
+public class EditPrescriptionCommandParser implements Parser<EditPrescriptionCommand> {
 
     /**
      * Parses the given {@code String} of arguments in the context of the EditPrescriptionCommand
@@ -29,10 +30,6 @@ public class EditPrescriptionCommandParser {
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NRIC, PREFIX_NAME, PREFIX_DATE,
                 PREFIX_INSTRUCTION);
 
-        if (argMultimap.getValue(PREFIX_NRIC).isPresent()) {
-            throw new ParseException(EditPrescriptionCommand.MESSAGE_NRIC_EDIT_NOT_ALLOWED);
-        }
-
         Index index;
 
         try {
@@ -40,6 +37,10 @@ public class EditPrescriptionCommandParser {
         } catch (ParseException pe) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                     EditPrescriptionCommand.MESSAGE_USAGE), pe);
+        }
+
+        if (argMultimap.getValue(PREFIX_NRIC).isPresent()) {
+            throw new ParseException(EditPrescriptionCommand.MESSAGE_NRIC_EDIT_NOT_ALLOWED);
         }
 
         EditPrescriptionCommand.EditPrescriptionDescriptor editPrescriptionDescriptor =

--- a/src/main/java/seedu/address/logic/parser/testresult/EditTestResultCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/testresult/EditTestResultCommandParser.java
@@ -11,13 +11,14 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.testresult.EditTestResultCommand;
 import seedu.address.logic.parser.ArgumentMultimap;
 import seedu.address.logic.parser.ArgumentTokenizer;
+import seedu.address.logic.parser.Parser;
 import seedu.address.logic.parser.ParserUtil;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
  * Parses input arguments and creates a new EditTestResultCommand object
  */
-public class EditTestResultCommandParser {
+public class EditTestResultCommandParser implements Parser<EditTestResultCommand> {
     /**
      * Parses the given {@code String} of arguments in the context of the EditTestResultCommand
      * and returns an EditTestResultCommand object for execution.
@@ -25,34 +26,41 @@ public class EditTestResultCommandParser {
      */
     public EditTestResultCommand parse(String args) throws ParseException {
         requireNonNull(args);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NRIC, PREFIX_TESTDATE,
+                PREFIX_MEDICALTEST, PREFIX_RESULT);
+
+        Index index;
+
         try {
-            ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NRIC, PREFIX_TESTDATE,
-                    PREFIX_MEDICALTEST, PREFIX_RESULT);
-
-            Index index = ParserUtil.parseIndex(argMultimap.getPreamble());
-
-            EditTestResultCommand.EditTestResultDescriptor editTestResultDescriptor =
-                    new EditTestResultCommand.EditTestResultDescriptor();
-
-            if (argMultimap.getValue(PREFIX_NRIC).isPresent()) {
-                editTestResultDescriptor.setNric(ParserUtil.parseNric(argMultimap.getValue(PREFIX_NRIC).get()));
-            }
-            if (argMultimap.getValue(PREFIX_TESTDATE).isPresent()) {
-                editTestResultDescriptor.setTestDate(ParserUtil.parseTestDate(
-                        argMultimap.getValue(PREFIX_TESTDATE).get()));
-            }
-            if (argMultimap.getValue(PREFIX_MEDICALTEST).isPresent()) {
-                editTestResultDescriptor.setMedicalTest(ParserUtil.parseMedicalTest(
-                        argMultimap.getValue(PREFIX_MEDICALTEST).get()));
-            }
-            if (argMultimap.getValue(PREFIX_RESULT).isPresent()) {
-                editTestResultDescriptor.setResult(ParserUtil.parseResult(argMultimap.getValue(PREFIX_RESULT).get()));
-            }
-
-            return new EditTestResultCommand(index, editTestResultDescriptor);
+            index = ParserUtil.parseIndex(argMultimap.getPreamble());
         } catch (ParseException pe) {
-            throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditTestResultCommand.MESSAGE_USAGE), pe);
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    EditTestResultCommand.MESSAGE_USAGE), pe);
         }
+
+        if (argMultimap.getValue(PREFIX_NRIC).isPresent()) {
+            throw new ParseException(EditTestResultCommand.MESSAGE_NRIC_EDIT_NOT_ALLOWED);
+        }
+
+        EditTestResultCommand.EditTestResultDescriptor editTestResultDescriptor =
+                new EditTestResultCommand.EditTestResultDescriptor();
+
+        if (argMultimap.getValue(PREFIX_TESTDATE).isPresent()) {
+            editTestResultDescriptor.setTestDate(ParserUtil.parseTestDate(
+                    argMultimap.getValue(PREFIX_TESTDATE).get()));
+        }
+        if (argMultimap.getValue(PREFIX_MEDICALTEST).isPresent()) {
+            editTestResultDescriptor.setMedicalTest(ParserUtil.parseMedicalTest(
+                    argMultimap.getValue(PREFIX_MEDICALTEST).get()));
+        }
+        if (argMultimap.getValue(PREFIX_RESULT).isPresent()) {
+            editTestResultDescriptor.setResult(ParserUtil.parseResult(argMultimap.getValue(PREFIX_RESULT).get()));
+        }
+
+        if (!editTestResultDescriptor.isAnyFieldEdited()) {
+            throw new ParseException(EditTestResultCommand.MESSAGE_NOT_EDITED);
+        }
+
+        return new EditTestResultCommand(index, editTestResultDescriptor);
     }
 }

--- a/src/main/java/seedu/address/model/consultation/Consultation.java
+++ b/src/main/java/seedu/address/model/consultation/Consultation.java
@@ -4,6 +4,7 @@ import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.util.Objects;
 
+import seedu.address.model.contact.Contact;
 import seedu.address.model.patient.Nric;
 
 /**

--- a/src/main/java/seedu/address/model/consultation/Consultation.java
+++ b/src/main/java/seedu/address/model/consultation/Consultation.java
@@ -4,7 +4,6 @@ import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.util.Objects;
 
-import seedu.address.model.contact.Contact;
 import seedu.address.model.patient.Nric;
 
 /**

--- a/src/main/java/seedu/address/model/patient/Nric.java
+++ b/src/main/java/seedu/address/model/patient/Nric.java
@@ -9,7 +9,8 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  */
 public class Nric {
     public static final String MESSAGE_CONSTRAINTS =
-            "NRIC should be alphanumeric, starting with either S, T, F, G, M, followed by 7 digits "
+            "NRIC should be a Singapore-registered NRIC which consists alphanumeric, "
+                    + "starting with either S, T, F, G, M, followed by 7 digits "
                     + "and ending with any character.";
     public static final String VALIDATION_REGEX = "^[STFGM]\\d{7}[A-Z]$";
     public final String value;

--- a/src/main/resources/view/SignupWindow.fxml
+++ b/src/main/resources/view/SignupWindow.fxml
@@ -8,14 +8,12 @@
 <?import javafx.scene.layout.StackPane?>
 <?import javafx.scene.layout.VBox?>
 <?import javafx.stage.Stage?>
-
 <?import javafx.scene.control.PasswordField?>
-
 <?import javafx.scene.image.ImageView?>
-<?import javafx.scene.text.TextFlow?>
 <?import javafx.scene.layout.HBox?>
+
 <fx:root resizable="false" title="Welcome to MedBook" type="javafx.stage.Stage"
-         minWidth="600" minHeight="800" xmlns="http://javafx.com/javafx/11"
+         minWidth="600" minHeight="800" xmlns="http://javafx.com/javafx/8"
          xmlns:fx="http://javafx.com/fxml/1"
          onCloseRequest="#handleExit">
     <icons>

--- a/src/main/resources/view/consultation/ConsultationListCard.fxml
+++ b/src/main/resources/view/consultation/ConsultationListCard.fxml
@@ -10,12 +10,12 @@
 <?import javafx.scene.layout.VBox?>
 <?import javafx.scene.text.Font?>
 
-<HBox id="cardPane" fx:id="cardPane" prefHeight="208.0" prefWidth="383.0" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
-  <GridPane prefHeight="191.0" prefWidth="312.0" HBox.hgrow="ALWAYS">
+<HBox id="cardPane" fx:id="cardPane" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
+  <GridPane HBox.hgrow="ALWAYS">
     <columnConstraints>
-      <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="150" />
+      <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="150"/>
     </columnConstraints>
-    <VBox alignment="CENTER_LEFT" minHeight="105" prefHeight="215.0" prefWidth="312.0" GridPane.columnIndex="0">
+    <VBox alignment="CENTER_LEFT" minHeight="105" GridPane.columnIndex="0">
       <padding>
         <Insets bottom="5" left="15" right="5" top="5" />
       </padding>
@@ -35,25 +35,24 @@
             <font>
                 <Font name="System Bold" size="14.0" />
             </font></Label>
-         <Region prefHeight="200.0" prefWidth="200.0" />
       <Label text="Diagnosis">
             <font>
                <Font size="14.0" />
-            </font></Label>
-      <Label fx:id="diagnosis" styleClass="cell_small_label" text="\$diagnosis" />
-         <Region prefHeight="200.0" prefWidth="200.0" />
+            </font>
+      </Label>
+      <Label fx:id="diagnosis" styleClass="cell_small_label" text="\$diagnosis" wrapText="true" />
       <Label text="Fee">
             <font>
                <Font size="14.0" />
             </font></Label>
       <Label fx:id="fee" styleClass="cell_small_label" text="\$fee" />
-         <Region prefHeight="200.0" prefWidth="200.0" />
+
       <Label text="Notes">
             <font>
                <Font size="14.0" />
             </font></Label>
       <Label fx:id="notes" styleClass="cell_small_label" text="\$notes" />
-         <Region prefHeight="200.0" prefWidth="200.0" />
+
     </VBox>
       <rowConstraints>
          <RowConstraints />

--- a/src/main/resources/view/contact/ContactListCard.fxml
+++ b/src/main/resources/view/contact/ContactListCard.fxml
@@ -29,7 +29,7 @@
             </HBox>
             <FlowPane fx:id="tags" />
             <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" />
-            <Label fx:id="address" styleClass="cell_small_label" text="\$address" />
+            <Label fx:id="address" styleClass="cell_small_label" text="\$address" wrapText="true"/>
             <Label fx:id="email" styleClass="cell_small_label" text="\$email" />
         </VBox>
     </GridPane>

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -1,7 +1,7 @@
 package seedu.address.logic;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static seedu.address.commons.core.Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_PATIENT_DISPLAYED_INDEX;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
@@ -60,7 +60,7 @@ public class LogicManagerTest {
     @Test
     public void execute_commandExecutionError_throwsCommandException() {
         String deleteCommand = "delete 9";
-        assertCommandException(deleteCommand, MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        assertCommandException(deleteCommand, MESSAGE_INVALID_PATIENT_DISPLAYED_INDEX);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -63,8 +63,8 @@ public class CommandTestUtil {
     public static final String PREAMBLE_WHITESPACE = "\t  \r  \n";
     public static final String PREAMBLE_NON_EMPTY = "NonEmptyPreamble";
 
-    public static final EditCommand.EditPersonDescriptor DESC_AMY;
-    public static final EditCommand.EditPersonDescriptor DESC_BOB;
+    public static final EditCommand.EditPatientDescriptor DESC_AMY;
+    public static final EditCommand.EditPatientDescriptor DESC_BOB;
 
     static {
         DESC_AMY = new EditPatientDescriptorBuilder().withName(VALID_NAME_AMY)

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -44,7 +44,7 @@ public class DeleteCommandTest {
         Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPatientList().size() + 1);
         DeleteCommand deleteCommand = new DeleteCommand(outOfBoundIndex);
 
-        assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_PATIENT_DISPLAYED_INDEX);
     }
 
     @Test
@@ -73,7 +73,7 @@ public class DeleteCommandTest {
 
         DeleteCommand deleteCommand = new DeleteCommand(outOfBoundIndex);
 
-        assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_PATIENT_DISPLAYED_INDEX);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -18,7 +18,7 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
-import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
+import seedu.address.logic.commands.EditCommand.EditPatientDescriptor;
 import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
@@ -37,10 +37,10 @@ public class EditCommandTest {
     @Test
     public void execute_allFieldsSpecifiedUnfilteredList_success() {
         Patient editedPatient = new PatientBuilder().build();
-        EditPersonDescriptor descriptor = new EditPatientDescriptorBuilder(editedPatient).build();
+        EditPatientDescriptor descriptor = new EditPatientDescriptorBuilder(editedPatient).build();
         EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON, descriptor);
 
-        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, editedPatient);
+        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PATIENT_SUCCESS, editedPatient);
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
         expectedModel.setPerson(model.getFilteredPatientList().get(0), editedPatient);
@@ -57,11 +57,11 @@ public class EditCommandTest {
         Patient editedPatient = personInList.withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB)
                 .withTags(VALID_TAG_HUSBAND).build();
 
-        EditPersonDescriptor descriptor = new EditPatientDescriptorBuilder().withName(VALID_NAME_BOB)
+        EditPatientDescriptor descriptor = new EditPatientDescriptorBuilder().withName(VALID_NAME_BOB)
                 .withPhone(VALID_PHONE_BOB).withTags(VALID_TAG_HUSBAND).build();
         EditCommand editCommand = new EditCommand(indexLastPerson, descriptor);
 
-        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, editedPatient);
+        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PATIENT_SUCCESS, editedPatient);
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
         expectedModel.setPerson(lastPatient, editedPatient);
@@ -71,10 +71,10 @@ public class EditCommandTest {
 
     @Test
     public void execute_noFieldSpecifiedUnfilteredList_success() {
-        EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON, new EditPersonDescriptor());
+        EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON, new EditPatientDescriptor());
         Patient editedPatient = model.getFilteredPatientList().get(INDEX_FIRST_PERSON.getZeroBased());
 
-        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, editedPatient);
+        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PATIENT_SUCCESS, editedPatient);
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
 
@@ -90,7 +90,7 @@ public class EditCommandTest {
         EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON,
                 new EditPatientDescriptorBuilder().withName(VALID_NAME_BOB).build());
 
-        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, editedPatient);
+        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PATIENT_SUCCESS, editedPatient);
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
         expectedModel.setPerson(model.getFilteredPatientList().get(0), editedPatient);
@@ -101,10 +101,10 @@ public class EditCommandTest {
     @Test
     public void execute_duplicatePersonUnfilteredList_failure() {
         Patient firstPatient = model.getFilteredPatientList().get(INDEX_FIRST_PERSON.getZeroBased());
-        EditPersonDescriptor descriptor = new EditPatientDescriptorBuilder(firstPatient).build();
+        EditPatientDescriptor descriptor = new EditPatientDescriptorBuilder(firstPatient).build();
         EditCommand editCommand = new EditCommand(INDEX_SECOND_PERSON, descriptor);
 
-        assertCommandFailure(editCommand, model, EditCommand.MESSAGE_DUPLICATE_PERSON);
+        assertCommandFailure(editCommand, model, EditCommand.MESSAGE_DUPLICATE_PATIENT);
     }
 
     @Test
@@ -116,16 +116,16 @@ public class EditCommandTest {
         EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON,
                 new EditPatientDescriptorBuilder(patientInList).build());
 
-        assertCommandFailure(editCommand, model, EditCommand.MESSAGE_DUPLICATE_PERSON);
+        assertCommandFailure(editCommand, model, EditCommand.MESSAGE_DUPLICATE_PATIENT);
     }
 
     @Test
     public void execute_invalidPersonIndexUnfilteredList_failure() {
         Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPatientList().size() + 1);
-        EditPersonDescriptor descriptor = new EditPatientDescriptorBuilder().withName(VALID_NAME_BOB).build();
+        EditPatientDescriptor descriptor = new EditPatientDescriptorBuilder().withName(VALID_NAME_BOB).build();
         EditCommand editCommand = new EditCommand(outOfBoundIndex, descriptor);
 
-        assertCommandFailure(editCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        assertCommandFailure(editCommand, model, Messages.MESSAGE_INVALID_PATIENT_DISPLAYED_INDEX);
     }
 
     /**
@@ -142,7 +142,7 @@ public class EditCommandTest {
         EditCommand editCommand = new EditCommand(outOfBoundIndex,
                 new EditPatientDescriptorBuilder().withName(VALID_NAME_BOB).build());
 
-        assertCommandFailure(editCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        assertCommandFailure(editCommand, model, Messages.MESSAGE_INVALID_PATIENT_DISPLAYED_INDEX);
     }
 
     @Test
@@ -150,7 +150,7 @@ public class EditCommandTest {
         final EditCommand standardCommand = new EditCommand(INDEX_FIRST_PERSON, DESC_AMY);
 
         // same values -> returns true
-        EditPersonDescriptor copyDescriptor = new EditPersonDescriptor(DESC_AMY);
+        EditPatientDescriptor copyDescriptor = new EditPatientDescriptor(DESC_AMY);
         EditCommand commandWithSameValues = new EditCommand(INDEX_FIRST_PERSON, copyDescriptor);
         assertTrue(standardCommand.equals(commandWithSameValues));
 

--- a/src/test/java/seedu/address/logic/commands/EditPatientDescriptorTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditPatientDescriptorTest.java
@@ -12,7 +12,7 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 
 import org.junit.jupiter.api.Test;
 
-import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
+import seedu.address.logic.commands.EditCommand.EditPatientDescriptor;
 import seedu.address.testutil.EditPatientDescriptorBuilder;
 
 public class EditPatientDescriptorTest {
@@ -20,7 +20,7 @@ public class EditPatientDescriptorTest {
     @Test
     public void equals() {
         // same values -> returns true
-        EditPersonDescriptor descriptorWithSameValues = new EditPersonDescriptor(DESC_AMY);
+        EditPatientDescriptor descriptorWithSameValues = new EditPatientDescriptor(DESC_AMY);
         assertTrue(DESC_AMY.equals(descriptorWithSameValues));
 
         // same object -> returns true
@@ -36,7 +36,7 @@ public class EditPatientDescriptorTest {
         assertFalse(DESC_AMY.equals(DESC_BOB));
 
         // different name -> returns false
-        EditPersonDescriptor editedAmy = new EditPatientDescriptorBuilder(DESC_AMY).withName(VALID_NAME_BOB).build();
+        EditPatientDescriptor editedAmy = new EditPatientDescriptorBuilder(DESC_AMY).withName(VALID_NAME_BOB).build();
         assertFalse(DESC_AMY.equals(editedAmy));
 
         // different phone -> returns false

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -3,7 +3,7 @@ package seedu.address.logic.commands;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.address.commons.core.Messages.MESSAGE_PERSONS_LISTED_OVERVIEW;
+import static seedu.address.commons.core.Messages.MESSAGE_PATIENTS_LISTED_OVERVIEW;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.testutil.TypicalPatients.CARL;
 import static seedu.address.testutil.TypicalPatients.ELLE;
@@ -56,7 +56,7 @@ public class FindCommandTest {
 
     @Test
     public void execute_zeroKeywords_noPersonFound() {
-        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
+        String expectedMessage = String.format(MESSAGE_PATIENTS_LISTED_OVERVIEW, 0);
         NameContainsKeywordsPredicate predicate = preparePredicate(" ");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredPatientList(predicate);
@@ -66,7 +66,7 @@ public class FindCommandTest {
 
     @Test
     public void execute_multipleKeywords_multiplePersonsFound() {
-        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 3);
+        String expectedMessage = String.format(MESSAGE_PATIENTS_LISTED_OVERVIEW, 3);
         NameContainsKeywordsPredicate predicate = preparePredicate("Kurz Elle Kunz");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredPatientList(predicate);

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -6,6 +6,7 @@ import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalPatients.getTypicalAddressBook;
 
 import java.util.Arrays;
 import java.util.List;
@@ -23,6 +24,9 @@ import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ViewCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
 import seedu.address.model.patient.NameContainsKeywordsPredicate;
 import seedu.address.model.patient.Patient;
 import seedu.address.testutil.EditPatientDescriptorBuilder;
@@ -32,6 +36,7 @@ import seedu.address.testutil.PersonUtil;
 public class AddressBookParserTest {
 
     private final AddressBookParser parser = new AddressBookParser();
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
 
     @Test
     public void parseCommand_add() throws Exception {
@@ -54,12 +59,13 @@ public class AddressBookParserTest {
     }
 
     @Test
-    public void parseCommand_edit() throws Exception {
+    public void parseCommand_editNric_throwsParseException() {
         Patient patient = new PatientBuilder().build();
         EditPatientDescriptor descriptor = new EditPatientDescriptorBuilder(patient).build();
-        EditCommand command = (EditCommand) parser.parseCommand(EditCommand.COMMAND_WORD + " "
-                + INDEX_FIRST_PERSON.getOneBased() + " " + PersonUtil.getEditPersonDescriptorDetails(descriptor));
-        assertEquals(new EditCommand(INDEX_FIRST_PERSON, descriptor), command);
+        assertThrows(ParseException.class, EditCommand.MESSAGE_NRIC_EDIT_NOT_ALLOWED, () ->
+                parser.parseCommand(EditCommand.COMMAND_WORD + " "
+                        + INDEX_FIRST_PERSON.getOneBased() + " "
+                        + PersonUtil.getEditPersonDescriptorDetails(descriptor)));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -17,7 +17,7 @@ import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.EditCommand;
-import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
+import seedu.address.logic.commands.EditCommand.EditPatientDescriptor;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
@@ -56,7 +56,7 @@ public class AddressBookParserTest {
     @Test
     public void parseCommand_edit() throws Exception {
         Patient patient = new PatientBuilder().build();
-        EditPersonDescriptor descriptor = new EditPatientDescriptorBuilder(patient).build();
+        EditPatientDescriptor descriptor = new EditPatientDescriptorBuilder(patient).build();
         EditCommand command = (EditCommand) parser.parseCommand(EditCommand.COMMAND_WORD + " "
                 + INDEX_FIRST_PERSON.getOneBased() + " " + PersonUtil.getEditPersonDescriptorDetails(descriptor));
         assertEquals(new EditCommand(INDEX_FIRST_PERSON, descriptor), command);

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -35,7 +35,7 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.EditCommand;
-import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
+import seedu.address.logic.commands.EditCommand.EditPatientDescriptor;
 import seedu.address.model.contact.Address;
 import seedu.address.model.contact.Email;
 import seedu.address.model.contact.Phone;
@@ -111,7 +111,7 @@ public class EditCommandParserTest {
         String userInput = targetIndex.getOneBased() + PHONE_DESC_BOB + TAG_DESC_HUSBAND
                 + EMAIL_DESC_AMY + ADDRESS_DESC_AMY + NAME_DESC_AMY + TAG_DESC_FRIEND;
 
-        EditPersonDescriptor descriptor = new EditPatientDescriptorBuilder().withName(VALID_NAME_AMY)
+        EditPatientDescriptor descriptor = new EditPatientDescriptorBuilder().withName(VALID_NAME_AMY)
                 .withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_AMY).withAddress(VALID_ADDRESS_AMY)
                 .withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND).build();
         EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
@@ -124,7 +124,7 @@ public class EditCommandParserTest {
         Index targetIndex = INDEX_FIRST_PERSON;
         String userInput = targetIndex.getOneBased() + PHONE_DESC_BOB + EMAIL_DESC_AMY;
 
-        EditPersonDescriptor descriptor = new EditPatientDescriptorBuilder().withPhone(VALID_PHONE_BOB)
+        EditPatientDescriptor descriptor = new EditPatientDescriptorBuilder().withPhone(VALID_PHONE_BOB)
                 .withEmail(VALID_EMAIL_AMY).build();
         EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
 
@@ -136,7 +136,7 @@ public class EditCommandParserTest {
         // name
         Index targetIndex = INDEX_THIRD_PERSON;
         String userInput = targetIndex.getOneBased() + NAME_DESC_AMY;
-        EditPersonDescriptor descriptor = new EditPatientDescriptorBuilder().withName(VALID_NAME_AMY).build();
+        EditPatientDescriptor descriptor = new EditPatientDescriptorBuilder().withName(VALID_NAME_AMY).build();
         EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
@@ -172,7 +172,7 @@ public class EditCommandParserTest {
                 + TAG_DESC_FRIEND + PHONE_DESC_AMY + ADDRESS_DESC_AMY + EMAIL_DESC_AMY + TAG_DESC_FRIEND
                 + PHONE_DESC_BOB + ADDRESS_DESC_BOB + EMAIL_DESC_BOB + TAG_DESC_HUSBAND;
 
-        EditPersonDescriptor descriptor = new EditPatientDescriptorBuilder().withPhone(VALID_PHONE_BOB)
+        EditPatientDescriptor descriptor = new EditPatientDescriptorBuilder().withPhone(VALID_PHONE_BOB)
                 .withEmail(VALID_EMAIL_BOB).withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_FRIEND, VALID_TAG_HUSBAND)
                 .build();
         EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
@@ -185,7 +185,7 @@ public class EditCommandParserTest {
         // no other valid values specified
         Index targetIndex = INDEX_FIRST_PERSON;
         String userInput = targetIndex.getOneBased() + INVALID_PHONE_DESC + PHONE_DESC_BOB;
-        EditPersonDescriptor descriptor = new EditPatientDescriptorBuilder().withPhone(VALID_PHONE_BOB).build();
+        EditPatientDescriptor descriptor = new EditPatientDescriptorBuilder().withPhone(VALID_PHONE_BOB).build();
         EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
@@ -203,7 +203,7 @@ public class EditCommandParserTest {
         Index targetIndex = INDEX_THIRD_PERSON;
         String userInput = targetIndex.getOneBased() + TAG_EMPTY;
 
-        EditPersonDescriptor descriptor = new EditPatientDescriptorBuilder().withTags().build();
+        EditPatientDescriptor descriptor = new EditPatientDescriptorBuilder().withTags().build();
         EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
 
         assertParseSuccess(parser, userInput, expectedCommand);

--- a/src/test/java/seedu/address/testutil/EditPatientDescriptorBuilder.java
+++ b/src/test/java/seedu/address/testutil/EditPatientDescriptorBuilder.java
@@ -9,7 +9,6 @@ import seedu.address.model.contact.Address;
 import seedu.address.model.contact.Email;
 import seedu.address.model.contact.Phone;
 import seedu.address.model.patient.Name;
-import seedu.address.model.patient.Nric;
 import seedu.address.model.patient.Patient;
 import seedu.address.model.tag.Tag;
 
@@ -39,14 +38,6 @@ public class EditPatientDescriptorBuilder {
         descriptor.setEmail(patient.getEmail());
         descriptor.setAddress(patient.getAddress());
         descriptor.setTags(patient.getTags());
-    }
-
-    /**
-     * Sets the {@code Nric} of the {@code EditPersonDescriptor} that we are building.
-     */
-    public EditPatientDescriptorBuilder withNric(String nric) {
-        descriptor.setNric(new Nric(nric));
-        return this;
     }
 
     /**

--- a/src/test/java/seedu/address/testutil/EditPatientDescriptorBuilder.java
+++ b/src/test/java/seedu/address/testutil/EditPatientDescriptorBuilder.java
@@ -4,7 +4,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
+import seedu.address.logic.commands.EditCommand.EditPatientDescriptor;
 import seedu.address.model.contact.Address;
 import seedu.address.model.contact.Email;
 import seedu.address.model.contact.Phone;
@@ -18,21 +18,21 @@ import seedu.address.model.tag.Tag;
  */
 public class EditPatientDescriptorBuilder {
 
-    private EditPersonDescriptor descriptor;
+    private EditPatientDescriptor descriptor;
 
     public EditPatientDescriptorBuilder() {
-        descriptor = new EditPersonDescriptor();
+        descriptor = new EditPatientDescriptor();
     }
 
-    public EditPatientDescriptorBuilder(EditPersonDescriptor descriptor) {
-        this.descriptor = new EditPersonDescriptor(descriptor);
+    public EditPatientDescriptorBuilder(EditPatientDescriptor descriptor) {
+        this.descriptor = new EditPatientDescriptor(descriptor);
     }
 
     /**
      * Returns an {@code EditPersonDescriptor} with fields containing {@code person}'s details
      */
     public EditPatientDescriptorBuilder(Patient patient) {
-        descriptor = new EditPersonDescriptor();
+        descriptor = new EditPatientDescriptor();
         descriptor.setNric(patient.getNric());
         descriptor.setName(patient.getName());
         descriptor.setPhone(patient.getPhone());
@@ -91,7 +91,7 @@ public class EditPatientDescriptorBuilder {
         return this;
     }
 
-    public EditPersonDescriptor build() {
+    public EditPatientDescriptor build() {
         return descriptor;
     }
 }

--- a/src/test/java/seedu/address/testutil/PersonUtil.java
+++ b/src/test/java/seedu/address/testutil/PersonUtil.java
@@ -10,7 +10,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import java.util.Set;
 
 import seedu.address.logic.commands.AddCommand;
-import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
+import seedu.address.logic.commands.EditCommand.EditPatientDescriptor;
 import seedu.address.model.patient.Patient;
 import seedu.address.model.tag.Tag;
 
@@ -45,7 +45,7 @@ public class PersonUtil {
     /**
      * Returns the part of command string for the given {@code EditPersonDescriptor}'s details.
      */
-    public static String getEditPersonDescriptorDetails(EditPersonDescriptor descriptor) {
+    public static String getEditPersonDescriptorDetails(EditPatientDescriptor descriptor) {
         StringBuilder sb = new StringBuilder();
         descriptor.getNric().ifPresent(nric -> sb.append(PREFIX_NRIC).append(nric.value).append(" "));
         descriptor.getName().ifPresent(name -> sb.append(PREFIX_NAME).append(name.fullName).append(" "));


### PR DESCRIPTION
This PR extends a new feature to edit a patient's contact in MedBook 📕 #68 and integrate all edit commands.

## New ✨
- MedBook now support editing patient's contact. Close #68 
- Disabled nric edit for `consultation`, `prescription`, `test`, `contact`, `medical` and `patient`

## Bugs Squashed 🐛
- Patch duplicate validation during editing in `consultation`, `prescription` and `test`.
- Patch empty field validation during editing in `consultation`, `prescription` and `test`.
- Patch input field validation error not shown in `consultation`, `prescription` and `test` .
- Patch card line not wrapping bug. Close #122 

## Improvement 🎇
- Add `Nric` edit validation to remind the user that `Nric` is disabled for editing.
- Integration checks with other attributes --  `consultation`, `prescription`, `test`, `contact`, `medical` and `patient`