### PR TITLE
Fix: Allow editable file to meet project constraint

### DIFF
--- a/src/main/java/seedu/address/MainApp.java
+++ b/src/main/java/seedu/address/MainApp.java
@@ -208,7 +208,6 @@ public class MainApp extends Application {
             storage.saveAddressBook(model.getAddressBook());
             storage.saveUserPrefs(model.getUserPrefs());
             authentication.createEncryptedFile(storage.getAddressBookFilePath());
-            FileUtil.deleteFile(storage.getAddressBookFilePath());
         } catch (IOException e) {
             logger.severe("Failed to save preferences " + StringUtil.getDetails(e));
         } catch (InvalidKeyException e) {

--- a/src/main/java/seedu/address/MainApp.java
+++ b/src/main/java/seedu/address/MainApp.java
@@ -15,7 +15,6 @@ import seedu.address.commons.core.LogsCenter;
 import seedu.address.commons.core.Version;
 import seedu.address.commons.exceptions.DataConversionException;
 import seedu.address.commons.util.ConfigUtil;
-import seedu.address.commons.util.FileUtil;
 import seedu.address.commons.util.StringUtil;
 import seedu.address.logic.Logic;
 import seedu.address.logic.LogicManager;

--- a/src/main/java/seedu/address/encryption/EncryptionManager.java
+++ b/src/main/java/seedu/address/encryption/EncryptionManager.java
@@ -92,7 +92,16 @@ public class EncryptionManager implements Encryption {
             fileIn.read(fileInitializationVector);
             cipher.init(Cipher.DECRYPT_MODE, secretKey, new IvParameterSpec(fileInitializationVector));
 
-            FileUtil.writeToFile(targetFile, decrypt(fileIn));
+            String decryptedContent = decrypt(fileIn);
+
+            // Skip writing decrypted content if there exists a data file
+            if (FileUtil.isFileExists(targetFile)) {
+                logger.info("Reading content from data file");
+                return;
+            }
+
+            logger.info("Reading content from encrypted file");
+            FileUtil.writeToFile(targetFile, decryptedContent);
 
             logger.fine("Contents decrypted");
         }
@@ -103,12 +112,10 @@ public class EncryptionManager implements Encryption {
      *
      * @param fileIn The input stream of the given file.
      * @return The string content of the decrypted file.
-     * @throws InvalidAlgorithmParameterException If decryption algorithm is invalid.
-     * @throws InvalidKeyException If decryption secret key is invalid.
      * @throws IOException If file reading causes error.
      */
-    public String decrypt(FileInputStream fileIn) throws InvalidAlgorithmParameterException,
-            InvalidKeyException, IOException {
+    public String decrypt(FileInputStream fileIn) throws
+            IOException {
         String content;
 
         try (

--- a/src/main/resources/view/ResultDisplay.fxml
+++ b/src/main/resources/view/ResultDisplay.fxml
@@ -3,6 +3,7 @@
 <?import javafx.scene.control.TextArea?>
 <?import javafx.scene.layout.StackPane?>
 
-<StackPane fx:id="placeHolder" styleClass="pane-with-border" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
+<StackPane fx:id="placeHolder" styleClass="pane-with-border"
+           xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
   <TextArea fx:id="resultDisplay" editable="false" styleClass="result-display" />
 </StackPane>

--- a/src/main/resources/view/SignupWindow.fxml
+++ b/src/main/resources/view/SignupWindow.fxml
@@ -15,7 +15,7 @@
 <?import javafx.scene.text.TextFlow?>
 <?import javafx.scene.layout.HBox?>
 <fx:root resizable="false" title="Welcome to MedBook" type="javafx.stage.Stage"
-         minWidth="600" minHeight="800" xmlns="http://javafx.com/javafx/11"
+         minWidth="600" minHeight="800" xmlns="http://javafx.com/javafx/8"
          xmlns:fx="http://javafx.com/fxml/1"
          onCloseRequest="#handleExit">
     <icons>


### PR DESCRIPTION
This PR allow MedBook to retain an editable file `medbook.json` as mentioned in the project constraint. 

## Note
1. MedBook will always read from the editable data file `medbook.json` by default (including first time setup).
2. MedBook will read from the encrypted data file `secret.enc` if users choose to remove `medbook.json`  for security reasons. It is important to note that removing  `medbook.json` is totally optional if data privacy is not the main concern.
3. Users now can edit the data file manually, provided they know what they are doing as this is a destructive action. 
4. Users are highly encouraged to back up the data file locally prior to doing any manual editing to the data file as invalid inputs in the data file will cause MedBook to start with empty data. 
5. Users are not supposed to meddle (including deleting) with the encrypted file `secret.enc` as it was meant to encrypt MedBook data and password. Any attempts to modify the file content are considered a security attack.
6. In the worst case where `secret.enc` is deleted, the user will be required to set up a new password and a new MedBook is initialized if `medbook.json` does not exist.