### PR TITLE
Remove the redundant check for NRIC and allow keyword to match with NRIC

### DIFF
--- a/src/main/java/seedu/address/logic/commands/testresult/AddTestResultCommand.java
+++ b/src/main/java/seedu/address/logic/commands/testresult/AddTestResultCommand.java
@@ -24,7 +24,7 @@ public class AddTestResultCommand extends Command {
             + PREFIX_TYPE + "test"
             + ": Adds the results of a test taken for a patient in the MedBook. \n"
             + "Parameters: "
-            + PREFIX_TYPE + "test"
+            + PREFIX_TYPE + "test "
             + PREFIX_NRIC + "PATIENT_NRIC "
             + PREFIX_TESTDATE + "TEST_DATE "
             + PREFIX_MEDICALTEST + "MEDICAL_TEST "

--- a/src/main/java/seedu/address/model/medical/MedicalContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/medical/MedicalContainsKeywordsPredicate.java
@@ -4,7 +4,6 @@ import java.util.List;
 import java.util.function.Predicate;
 
 import seedu.address.commons.util.StringUtil;
-import seedu.address.logic.commands.ViewedNric;
 
 /**
  * Tests that a {@code Person}'s {@code Medical} matches any of the keywords given.

--- a/src/main/java/seedu/address/model/medical/MedicalContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/medical/MedicalContainsKeywordsPredicate.java
@@ -18,13 +18,9 @@ public class MedicalContainsKeywordsPredicate implements Predicate<Medical> {
 
     @Override
     public boolean test(Medical medical) {
-        boolean nricMatches = true;
-        if (ViewedNric.getViewedNric() != null) {
-            nricMatches = ViewedNric.getViewedNric() == medical.getPatientNric();
-        }
-
-        return nricMatches
-                && keywords.stream()
+        return keywords.stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(medical.getPatientNric().toString(), keyword))
+                || keywords.stream()
                 .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(medical.getAge().toString(), keyword))
                 || keywords.stream()
                 .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(medical.getBloodType().toString(), keyword))


### PR DESCRIPTION
This PR removes the redundant `isNotNull` check in FindMedical and allows the keyword to match with the NRIC for medical.